### PR TITLE
fix angle rotation bug

### DIFF
--- a/tools/boundary/boundary.py
+++ b/tools/boundary/boundary.py
@@ -298,11 +298,17 @@ class Segment():
         ny (int): Number of data points in the y direction.
     """
 
-    def __init__(self, num, border, hgrid, in_degrees=True, output_dir='.', regrid_dir=None):
+    def __init__(self, num, border, hgrid, in_degrees=False, output_dir='.', regrid_dir=None):
         self.num = num
         self.border = border
-        self.hgrid = hgrid
-        if in_degrees:
+        # Need to make a copy of hgrid so that the original is not modified multiple times 
+        # when creating multiple segments
+        self.hgrid = hgrid.copy(deep=True)
+        # Check if the angle_dx variable in ocean_hgrid has a 'units' attribute
+        angle_units = hgrid['angle_dx'].attrs.get('units', None)
+        # If the units attribute is degrees, or degrees were manually specified, convert to radians
+        if angle_units == 'degrees' or in_degrees:
+            print('Converting grid angle from degrees to radians')
             self.hgrid['angle_dx'] = np.radians(self.hgrid['angle_dx'])
         check_angle_range(self.hgrid['angle_dx'])
         self.segstr = f'segment_{self.num:03d}'

--- a/tools/boundary/write_glorys_boundary.py
+++ b/tools/boundary/write_glorys_boundary.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
 
     # Parse command-line arguments
     parser = argparse.ArgumentParser(description='Generate obc from Glorys')
-    parser.add_argument('--config', type=str, default=glorys_obc.yaml,
+    parser.add_argument('--config', type=str, default='glorys_obc.yaml',
                         help='Specify the YAML configuration file name')
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR fixes existing python script by having each segment make its own copy of the hgrid dataset before doing any units conversion.

The requirement to convert from `degrees` to `radians` is primarily a concern with the `NWA12` domain; in other domains,  the `angle` should be already in r`adians`. Therefore, this PR includes a change to assume by default that the `angle` is in `radians`. If the `angle_dx` variable in the `hgrid` dataset has a units attribute of `degrees`, it will automatically be converted to `radians`.