### PR TITLE
added felim to diazo iron limitation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,11 +30,11 @@
 	path = src/SIS2
 	url = https://github.com/NOAA-GFDL/SIS2.git
 	branch = dev/gfdl
-[submodule "src/ocean_BGC"]
-	path = src/ocean_BGC
-	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
-	branch = dev/cefi
 [submodule "src/MOM6"]
 	path = src/MOM6
 	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/MOM6.git
 	branch = stable/cefi
+[submodule "src/ocean_BGC"]
+	path = src/ocean_BGC
+	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
+	branch = addfelimdiazo/clean_code

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,4 +37,4 @@
 [submodule "src/ocean_BGC"]
 	path = src/ocean_BGC
 	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
-	branch = addfelimdiazo/clean_code
+	branch = dev/cefi


### PR DESCRIPTION
Due to the recent [PR](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC/pull/31) in ocean_BGC, we will have to update the ocean_BGC tag. 

While this fix changes answers, the effect is very small. It mainly removes small regions near river mouth where iron ends up being the most limiting nutrient simply because it takes a short time for high internal iron quotas to be established in high iron environments. Using the maximum of def_fe and felim removes this delay and puts iron on equal footing with N and P.

This adjustment also only effects the diazotrophs, which are generally a small fraction of the phytoplankton community.