### PR TITLE
Add ml_aclm_efold runtime paraqmeter in CI process

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,4 +37,4 @@
 [submodule "src/ocean_BGC"]
 	path = src/ocean_BGC
 	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
-	branch = dev/cefi
+	branch = lightandgrowth_cleanup/clean_code

--- a/ci/docker/Dockerfile.ci
+++ b/ci/docker/Dockerfile.ci
@@ -24,6 +24,10 @@ RUN ln -fs /opt/datasets ./
 
 WORKDIR /opt/MOM6_OBGC_examples/exps/OM4.single_column.COBALT
 
+# Run the sed command to add ml_aclm_efold = 4.6 after enforce_src_info = t
+# in field_table to maintain the baseline answers
+RUN sed -i '/enforce_src_info = t/a\ml_aclm_efold = 4.6' field_table
+
 RUN mpirun -np 1 /opt/MOM6_OBGC_examples/builds/build/docker-linux-gnu/ocean_ice/prod/MOM6SIS2
 
 # create ref folder

--- a/exps/NWA12.COBALT/field_table
+++ b/exps/NWA12.COBALT/field_table
@@ -19,6 +19,7 @@
 ###.................................................
 "namelists","ocean_mod","generic_COBALT"
 enforce_src_info = f
+ml_aclm_efold = 4.6
 alk_obc_src_file_name = bgc_esper_1993_2022.nc
 alk_obc_lfac_in = 0.03
 alk_obc_lfac_out = 1.0


### PR DESCRIPTION
Due to ocean_BGC side new [PR](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC/pull/39), the baseline answers have changed. To maintain the current answers, we have introduced a runtime parameter change in the `field_table` for the CI test. This change will ensure that the original answers are maintained until we have comprehensively tested the new default.