### PR TITLE
update ci workflows

### DIFF
--- a/.github/workflows/CEFI_MOM6-ci.yaml
+++ b/.github/workflows/CEFI_MOM6-ci.yaml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: ${{ github.run_id }}/CEFI_MOM6_CHECK
+        fetch-depth: 1  
         submodules: recursive
 
     - name: Build MOM6SIS2

--- a/.github/workflows/get_glorys_test.yaml
+++ b/.github/workflows/get_glorys_test.yaml
@@ -1,8 +1,6 @@
 name: get_glorys_data_ci
 
 on:
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '0 12 * * *'    
 

--- a/.github/workflows/mom6_cobalt_1D.yaml
+++ b/.github/workflows/mom6_cobalt_1D.yaml
@@ -21,6 +21,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
+        fetch-depth: 1
         submodules: recursive
         
     - name: Build mom6-sis2-cobalt
@@ -33,7 +34,7 @@ jobs:
     - name: Download 1d model dataset
       working-directory: ./exps
       run: | 
-       wget -q ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/1d_datasets.tar.gz && tar -zxvf 1d_datasets.tar.gz && rm -rf 1d_datasets.tar.gz
+       wget -q ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz
 
     - name: Run 1D toy case and check repro across restarts
       working-directory: ./exps/OM4.single_column.COBALT


### PR DESCRIPTION
Inspired by #27, I cleaned up our `1d_datasets.tar.gz` to keep only the necessary input data. I also adapted a shallow clone and hope this will help reduce checkout time. This reduced download time from 90s to 6s.