### PR TITLE
Increased job runtimes to 13 hours 

### DIFF
--- a/xmls/NWA12/CEFI_NWA12_cobalt.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt.xml
@@ -597,7 +597,7 @@ MOM_OVERRIDE_EOF
     <runtime>
       <production simTime="$(PROD_SIMTIME)" units="years">
         <segment simTime="12" units="months"/>
-        <resources jobWallclock="08:00:00" segRuntime="08:00:00">
+        <resources jobWallclock="13:00:00" segRuntime="13:00:00">
           <ice                          layout = "50,50" io_layout = "1,1" mask_table="mask_table.854.50x50"/>
           <ocn ranks="1646" threads="1" layout = "50,50" io_layout = "1,1" mask_table="mask_table.854.50x50"/>
         </resources>


### PR DESCRIPTION
Changed job time from 8:00:00 to 13:00:00 to prevent a jobtime failure while running the model. It seems like the model takes longer to run than it used to -- ~ 1 hour per month. 