### PR TITLE
Add config file for diagnostic scripts and use it to generalize sst_eval.py

### DIFF
--- a/diagnostics/physics/config.yaml
+++ b/diagnostics/physics/config.yaml
@@ -30,6 +30,9 @@ y:
     min: 4
     max: 59
 
+# Projection ( current options are either NorthPolarSterio for the arctic, or PlateCarree for all other domains
+projection: 'NorthPolarSterio'
+
 # Figure size
 fig_width: 11
 fig_height: 14

--- a/diagnostics/physics/config.yaml
+++ b/diagnostics/physics/config.yaml
@@ -30,8 +30,9 @@ y:
     min: 4
     max: 59
 
-# Projection ( current options are either NorthPolarSterio for the arctic, or PlateCarree for all other domains
-projection: 'NorthPolarSterio'
+# Projection ( current options are either NorthPolarStereo for the arctic, or PlateCarree for all other domains
+projection_grid: 'PlateCarree'
+projection_data: 'PlateCarree'
 
 # Figure size
 fig_width: 11

--- a/diagnostics/physics/config.yaml
+++ b/diagnostics/physics/config.yaml
@@ -2,14 +2,7 @@ figures_dir: 'figures/'
 glorys: '/work/acr/mom6/diagnostics/glorys/glorys_sfc.nc'
 model_grid: '../data/geography/ocean_static.nc'
 
-# List of variables to rename
-rename_vars:
-    - geolon
-    - geolat
-    - geolon_c
-    - geolat_c
-
-# Actually mappings for what each variable in above list should be renamed to
+# Variables to rename
 rename_map:
     geolon: lon
     geolat: lat
@@ -37,6 +30,18 @@ y:
     min: 4
     max: 59
 
+# Figure size
+fig_width: 11
+fig_height: 14
+
+# Location of skill score annotations in plot
+text_x: -98.5
+text_y: 54
+
+# Space between skill score text
+text_xint: 4 # This is unused if col=1, so it is only included for completeness
+text_yint: 4
+
 # SST_eval settings
 oisst: '/work/acr/oisstv2/' 
 
@@ -45,7 +50,7 @@ levels_min: 2
 levels_max: 31
 levels_step: 2
 
-# Colorbar difference plots
+# Colorbar for sst difference plots
 bias_min: -2
 bias_max: 2.1
 bias_step: 0.25

--- a/diagnostics/physics/config.yaml
+++ b/diagnostics/physics/config.yaml
@@ -45,6 +45,7 @@ text_y: 54
 # Space between skill score text
 text_xint: 4 # This is unused if col=1, so it is only included for completeness
 text_yint: 4
+plot_lat: False
 
 # SST_eval settings
 oisst: '/work/acr/oisstv2/' 

--- a/diagnostics/physics/config.yaml
+++ b/diagnostics/physics/config.yaml
@@ -1,0 +1,51 @@
+figures_dir: 'figures/'
+glorys: '/work/acr/mom6/diagnostics/glorys/glorys_sfc.nc'
+model_grid: '../data/geography/ocean_static.nc'
+
+# List of variables to rename
+rename_vars:
+    - geolon
+    - geolat
+    - geolon_c
+    - geolat_c
+
+# Actually mappings for what each variable in above list should be renamed to
+rename_map:
+    geolon: lon
+    geolat: lat
+    geolon_c: lon_b
+    geolat_c: lat_b
+
+# Domain and plotting details
+domain: ocean_monthly
+
+# Lat/lon range 
+lat: 
+    south: 0
+    north: 60
+
+lon:
+    west: 260
+    east: 330
+
+# Xlim/ylim to plot
+x: 
+    min: -99
+    max: -35
+
+y:
+    min: 4
+    max: 59
+
+# SST_eval settings
+oisst: '/work/acr/oisstv2/' 
+
+# Colorbar for sst plots
+levels_min: 2
+levels_max: 31
+levels_step: 2
+
+# Colorbar difference plots
+bias_min: -2
+bias_max: 2.1
+bias_step: 0.25

--- a/diagnostics/physics/plot_common.py
+++ b/diagnostics/physics/plot_common.py
@@ -195,7 +195,7 @@ def process_glorys(config, target_grid):
     except AttributeError:
         glorys_lonc, glorys_latc = corners(glorys.longitude, glorys.latitude)
         logger.info("Glorys data is using longitude/latitude")
-    else:
+    except:
         logger.error("Name of longitude and latitude variables is unknown")
         raise Exception("Error: Lat/Latitude, Lon/Longitdue not found in glorys data")
 

--- a/diagnostics/physics/plot_common.py
+++ b/diagnostics/physics/plot_common.py
@@ -52,7 +52,7 @@ def get_map_norm(cmap, levels, no_offset=True):
     norm = BoundaryNorm(levels, ncolors=nlev, clip=False)
     return cmap, norm
 
-def annotate_skill(model, obs, ax, dim=['yh', 'xh'], x0=-98.5, y0=54, yint=4, xint=4, weights=None, cols=1, proj = ccrs.PlateCarree(), **kwargs):
+def annotate_skill(model, obs, ax, dim=['yh', 'xh'], x0=-98.5, y0=54, yint=4, xint=4, weights=None, cols=1, proj = ccrs.PlateCarree(), plot_lat=False,**kwargs):
     """
     Annotate an axis with model vs obs skill metrics
     """
@@ -60,17 +60,32 @@ def annotate_skill(model, obs, ax, dim=['yh', 'xh'], x0=-98.5, y0=54, yint=4, xi
     rmse = xskillscore.rmse(model, obs, dim=dim, skipna=True, weights=weights)
     corr = xskillscore.pearson_r(model, obs, dim=dim, skipna=True, weights=weights)
     medae = xskillscore.median_absolute_error(model, obs, dim=dim, skipna=True)
-    ax.text(x0, y0, f'Bias: {float(bias):2.2f}', transform=proj, **kwargs)
-    ax.text(x0, y0-yint, f'RMSE: {float(rmse):2.2f}', transform=proj, **kwargs)
-    if cols == 1:
-        ax.text(x0, y0-yint*2, f'MedAE: {float(medae):2.2f}', transform=proj, **kwargs)
-        ax.text(x0, y0-yint*3, f'Corr: {float(corr):2.2f}', transform=proj, **kwargs)
-    elif cols == 2:
-        ax.text(x0+xint, y0, f'MedAE: {float(medae):2.2f}', transform=proj, **kwargs)
-        ax.text(x0+xint, y0-yint, f'Corr: {float(corr):2.2f}', transform=proj, **kwargs)
+
+    # Set plot_lat=True in order to plot skill along a line of latitude. Otherwise, plot along longitude
+    if plot_lat:
+        ax.text(x0, y0, f'Bias: {float(bias):2.2f}', transform=proj, **kwargs)
+        ax.text(x0-xint, y0, f'RMSE: {float(rmse):2.2f}', transform=proj, **kwargs)
+        if cols == 1:
+            ax.text(x0-xint*2, y0, f'MedAE: {float(medae):2.2f}', transform=proj, **kwargs)
+            ax.text(x0-xint*3, y0, f'Corr: {float(corr):2.2f}', transform=proj, **kwargs)
+        elif cols == 2:
+            ax.text(x0, y0+yint, f'MedAE: {float(medae):2.2f}', transform=proj, **kwargs)
+            ax.text(x0-xint, y0+yint, f'Corr: {float(corr):2.2f}', transform=proj, **kwargs)
+        else:
+            raise ValueError(f'Unsupported number of columns: {cols}')
+
     else:
-        raise ValueError(f'Unsupported number of columns: {cols}')
-    
+        ax.text(x0, y0, f'Bias: {float(bias):2.2f}', transform=proj, **kwargs)
+        ax.text(x0, y0-yint, f'RMSE: {float(rmse):2.2f}', transform=proj, **kwargs)
+        if cols == 1:
+            ax.text(x0, y0-yint*2, f'MedAE: {float(medae):2.2f}', transform=proj, **kwargs)
+            ax.text(x0, y0-yint*3, f'Corr: {float(corr):2.2f}', transform=proj, **kwargs)
+        elif cols == 2:
+            ax.text(x0+xint, y0, f'MedAE: {float(medae):2.2f}', transform=proj, **kwargs)
+            ax.text(x0+xint, y0-yint, f'Corr: {float(corr):2.2f}', transform=proj, **kwargs)
+        else:
+            raise ValueError(f'Unsupported number of columns: {cols}')
+
 def autoextend_colorbar(ax, plot, plot_array=None, **kwargs):
     """
     Add a colorbar, setting the extend metric based on 

--- a/diagnostics/physics/plot_common.py
+++ b/diagnostics/physics/plot_common.py
@@ -46,7 +46,7 @@ def get_map_norm(cmap, levels, no_offset=True):
     norm = BoundaryNorm(levels, ncolors=nlev, clip=False)
     return cmap, norm
 
-def annotate_skill(model, obs, ax, dim=['yh', 'xh'], x0=-98.5, y0=54, yint=4, xint=4, weights=None, cols=1, **kwargs):
+def annotate_skill(model, obs, ax, dim=['yh', 'xh'], x0=-98.5, y0=54, yint=4, xint=4, weights=None, cols=1, proj = ccrs.PlateCarree(), **kwargs):
     """
     Annotate an axis with model vs obs skill metrics
     """
@@ -54,14 +54,14 @@ def annotate_skill(model, obs, ax, dim=['yh', 'xh'], x0=-98.5, y0=54, yint=4, xi
     rmse = xskillscore.rmse(model, obs, dim=dim, skipna=True, weights=weights)
     corr = xskillscore.pearson_r(model, obs, dim=dim, skipna=True, weights=weights)
     medae = xskillscore.median_absolute_error(model, obs, dim=dim, skipna=True)
-    ax.text(x0, y0, f'Bias: {float(bias):2.2f}', **kwargs)
-    ax.text(x0, y0-yint, f'RMSE: {float(rmse):2.2f}', **kwargs)
+    ax.text(x0, y0, f'Bias: {float(bias):2.2f}', transform=proj, **kwargs)
+    ax.text(x0, y0-yint, f'RMSE: {float(rmse):2.2f}', transform=proj, **kwargs)
     if cols == 1:
-        ax.text(x0, y0-yint*2, f'MedAE: {float(medae):2.2f}', **kwargs)
-        ax.text(x0, y0-yint*3, f'Corr: {float(corr):2.2f}', **kwargs)
+        ax.text(x0, y0-yint*2, f'MedAE: {float(medae):2.2f}', transform=proj, **kwargs)
+        ax.text(x0, y0-yint*3, f'Corr: {float(corr):2.2f}', transform=proj, **kwargs)
     elif cols == 2:
-        ax.text(x0+xint, y0, f'MedAE: {float(medae):2.2f}', **kwargs)
-        ax.text(x0+xint, y0-yint, f'Corr: {float(corr):2.2f}', **kwargs)
+        ax.text(x0+xint, y0, f'MedAE: {float(medae):2.2f}', transform=proj, **kwargs)
+        ax.text(x0+xint, y0-yint, f'Corr: {float(corr):2.2f}', transform=proj, **kwargs)
     else:
         raise ValueError(f'Unsupported number of columns: {cols}')
     

--- a/diagnostics/physics/sst_eval.py
+++ b/diagnostics/physics/sst_eval.py
@@ -20,7 +20,7 @@ from plot_common import annotate_skill, autoextend_colorbar, corners, get_map_no
 def plot_sst_eval(pp_root, config):
     model = open_var(pp_root, config['domain'], 'tos')
     model_grid = xarray.open_dataset( config['model_grid'] )
-    target_grid = model_grid[config['rename_vars']].rename(config['rename_map'])
+    target_grid = model_grid[config['rename_map'].keys()].rename(config['rename_map'])
     model_ave = model.mean('time').load()
 
     glorys = xarray.open_dataset( config['glorys'] ).squeeze()['thetao'] #.rename({'longitude': 'lon', 'latitude': 'lat'})
@@ -48,7 +48,7 @@ def plot_sst_eval(pp_root, config):
     oisst_ave = oisst.mean('time').load()
     mom_rg = mom_to_oisst(model_ave)
     delta_oisst = mom_rg - oisst_ave
-    fig = plt.figure(figsize=(11, 14))
+    fig = plt.figure(figsize=(config['fig_width'], config['fig_height']))
     grid = AxesGrid(fig, 111,
         axes_class=(GeoAxes, dict(projection=ccrs.PlateCarree())),
         nrows_ncols=(2, 3),
@@ -88,7 +88,7 @@ def plot_sst_eval(pp_root, config):
     # Model - OISST
     grid[2].pcolormesh(oisst_lonc, oisst_latc, delta_oisst, **bias_common)
     grid[2].set_title('(c) Model - OISST')
-    annotate_skill(mom_rg, oisst_ave, grid[2], dim=['lat', 'lon'])
+    annotate_skill(mom_rg, oisst_ave, grid[2], dim=['lat', 'lon'], x0=config['text_x'], y0=config['text_y'], yint=config['text_yint'])
 
     # GLORYS
     p1 = grid[4].pcolormesh(glorys_lonc, glorys_latc, glorys_ave, cmap=cmap, norm=norm)
@@ -102,7 +102,7 @@ def plot_sst_eval(pp_root, config):
     cbar2.ax.set_xlabel('SST difference (°C)')
     cbar2.ax.set_xticks([-2, -1, 0, 1, 2])
     grid[5].set_title('(e) Model - GLORYS12')
-    annotate_skill(model_ave, glorys_rg, grid[5], weights=model_grid.areacello)
+    annotate_skill(model_ave, glorys_rg, grid[5], weights=model_grid.areacello, x0=config['text_x'], y0=config['text_y'], yint=config['text_yint'])
 
     for ax in grid:
         ax.set_xlim(config['x']['min'], config['x']['max'])

--- a/diagnostics/physics/sst_eval.py
+++ b/diagnostics/physics/sst_eval.py
@@ -61,7 +61,7 @@ def plot_sst_eval(pp_root, config):
         cbar_mode='edge',
         cbar_pad=0.2,
         cbar_size='15%',
-        label_mode=''
+        label_mode='keep'
     )
     logger.info("Successfully created grid")
 
@@ -102,7 +102,7 @@ def plot_sst_eval(pp_root, config):
     # Model - OISST
     grid[2].pcolormesh(oisst_lonc, oisst_latc, delta_oisst, transform=proj,**bias_common)
     grid[2].set_title('(c) Model - OISST')
-    annotate_skill(mom_rg, oisst_ave, grid[2], dim=['lat', 'lon'], x0=config['text_x'], y0=config['text_y'], xint=config['text_xint'], plot_lat=config['plotlat'])
+    annotate_skill(mom_rg, oisst_ave, grid[2], dim=['lat', 'lon'], x0=config['text_x'], y0=config['text_y'], xint=config['text_xint'], plot_lat=config['plot_lat'])
     logger.info("Successfully plotted difference between model and oisst")
 
     # GLORYS

--- a/diagnostics/physics/sst_eval.py
+++ b/diagnostics/physics/sst_eval.py
@@ -14,7 +14,7 @@ import numpy as np
 import xarray
 import logging
 
-from plot_common import annotate_skill, autoextend_colorbar, corners, get_map_norm, open_var, load_config, process_oisst, process_glorys
+from plot_common import annotate_skill, autoextend_colorbar, get_map_norm, open_var, load_config, process_oisst, process_glorys
 
 # Configure logging for sst_eval
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ def plot_sst_eval(pp_root, config):
     # Model - OISST
     grid[2].pcolormesh(oisst_lonc, oisst_latc, delta_oisst, transform=proj,**bias_common)
     grid[2].set_title('(c) Model - OISST')
-    annotate_skill(mom_rg, oisst_ave, grid[2], dim=['lat', 'lon'], x0=config['text_x'], y0=config['text_y'], yint=config['text_yint'])
+    annotate_skill(mom_rg, oisst_ave, grid[2], dim=['lat', 'lon'], x0=config['text_x'], y0=config['text_y'], xint=config['text_xint'], plot_lat=config['plotlat'])
     logger.info("Successfully plotted difference between model and oisst")
 
     # GLORYS
@@ -118,7 +118,7 @@ def plot_sst_eval(pp_root, config):
     cbar2.ax.set_xlabel('SST difference (°C)')
     cbar2.ax.set_xticks([-2, -1, 0, 1, 2])
     grid[5].set_title('(e) Model - GLORYS12')
-    annotate_skill(model_ave, glorys_rg, grid[5], weights=model_grid.areacello, x0=config['text_x'], y0=config['text_y'], yint=config['text_yint'])
+    annotate_skill(model_ave, glorys_rg, grid[5], weights=model_grid.areacello, x0=config['text_x'], y0=config['text_y'], xint=config['text_xint'], plot_lat=config['plot_lat'])
     logger.info("Successfully plotted difference between glorys and model")
 
     for ax in grid:

--- a/diagnostics/physics/sst_eval.py
+++ b/diagnostics/physics/sst_eval.py
@@ -49,8 +49,15 @@ def plot_sst_eval(pp_root, config):
     mom_rg = mom_to_oisst(model_ave)
     delta_oisst = mom_rg - oisst_ave
     fig = plt.figure(figsize=(config['fig_width'], config['fig_height']))
+
+    # For now, sst_eval.py will only support a projection for the arctic and a projection for all other domains
+    if config['projection'] == 'NorthPolarSterio':
+        p = ccrs.NorthPolarSterio( central_longitude = -20 )
+    else:
+        p = ccrs.PlateCarree()
+
     grid = AxesGrid(fig, 111,
-        axes_class=(GeoAxes, dict(projection=ccrs.PlateCarree())),
+        axes_class=(GeoAxes, dict( projection = p )),
         nrows_ncols=(2, 3),
         axes_pad=0.3,
         cbar_location='bottom',

--- a/diagnostics/physics/sst_eval.py
+++ b/diagnostics/physics/sst_eval.py
@@ -30,10 +30,11 @@ def plot_sst_eval(pp_root, config):
     logger.info("MODEL_AVE: %s",model_ave)
     logger.info("Successfully opened model grid and took mean over time")
 
+    # Verify that xh/yh are set as coordinates, then make sure model coordinates match grid data
+    model_grid = model_grid.assign_coords( {'xh':model_grid.xh, 'yh':model_grid.yh } )
+    model_ave = xarray.align(model_grid, model_ave,join='override')[1]
+
     glorys_rg, glorys_ave, glorys_lonc, glorys_latc = process_glorys(config, target_grid)
-    # Transform all longitudes to the interval [-180, 180] to prevent data from getting cutoff when calculating delta_glorys
-    glorys_rg.coords['xh'] = (glorys_rg.coords['xh'] + 180) % 360 - 180
-    # glorys_rg = glorys_rg.sortby(glorys_rg.xh)
     delta_glorys = model_ave - glorys_rg
     logger.info("GLORYS_RG: %s",glorys_rg)
     logger.info("DELTA_GLORYS: %s",delta_glorys)

--- a/diagnostics/physics/sst_eval.py
+++ b/diagnostics/physics/sst_eval.py
@@ -3,7 +3,7 @@ Compare model SST with 1993--2019 data from OISST and GLORYS.
 Uses whatever model data can be found within the directory pp_root,
 and does not try to match the model and observed time periods.
 How to use:
-python sst_eval.py /archive/acr/fre/NWA/2023_04/NWA12_COBALT_2023_04_kpo4-coastatten-physics/gfdl.ncrc5-intel22-prod 
+python sst_eval.py -p /archive/acr/fre/NWA/2023_04/NWA12_COBALT_2023_04_kpo4-coastatten-physics/gfdl.ncrc5-intel22-prod -c config.yaml
 """
 
 import cartopy.crs as ccrs
@@ -17,23 +17,25 @@ import xesmf
 from plot_common import annotate_skill, autoextend_colorbar, corners, get_map_norm, open_var
 
 
-def plot_sst_eval(pp_root):
-    model = open_var(pp_root, 'ocean_monthly', 'tos')
-    model_grid = xarray.open_dataset('../data/geography/ocean_static.nc')
-    target_grid = model_grid[['geolon', 'geolat', 'geolon_c', 'geolat_c']].rename({'geolon': 'lon', 'geolat': 'lat', 'geolon_c': 'lon_b', 'geolat_c': 'lat_b'})
+def plot_sst_eval(pp_root, config):
+    model = open_var(pp_root, config['domain'], 'tos')
+    model_grid = xarray.open_dataset( config['model_grid'] )
+    target_grid = model_grid[config['rename_vars']].rename(config['rename_map'])
     model_ave = model.mean('time').load()
 
-    glorys = xarray.open_dataset('/work/acr/mom6/diagnostics/glorys/glorys_sfc.nc')['thetao'] #.rename({'longitude': 'lon', 'latitude': 'lat'})
-    glorys_lonc, glorys_latc = corners(glorys.lon, glorys.lat)
+    glorys = xarray.open_dataset( config['glorys'] ).squeeze()['thetao'] #.rename({'longitude': 'lon', 'latitude': 'lat'})
+    try:
+        glorys_lonc, glorys_latc = corners(glorys.lon, glorys.lat)
+    except:
+        glorys_lonc, glorys_latc = corners(glorys.longitude, glorys.latitude)
     glorys_ave = glorys.mean('time').load()
     glorys_to_mom = xesmf.Regridder(glorys_ave, target_grid, method='bilinear', unmapped_to_nan=True)
     glorys_rg = glorys_to_mom(glorys_ave)
     delta_glorys = model_ave - glorys_rg
-
     oisst = (
-        xarray.open_mfdataset([f'/work/acr/oisstv2/sst.month.mean.{y}.nc' for y in range(1993, 2020)])
+        xarray.open_mfdataset([config['oisst']+f'sst.month.mean.{y}.nc' for y in range(1993, 2020)])
         .sst
-        .sel(lat=slice(0, 60), lon=slice(360-100, 360-30))
+        .sel(lat=slice(config['lat']['south'], config['lat']['north']), lon=slice(config['lon']['west'] ,config['lon']['east']))
     )
     oisst_lonc, oisst_latc = corners(oisst.lon, oisst.lat)
     oisst_lonc -= 360
@@ -46,7 +48,6 @@ def plot_sst_eval(pp_root):
     oisst_ave = oisst.mean('time').load()
     mom_rg = mom_to_oisst(model_ave)
     delta_oisst = mom_rg - oisst_ave
-
     fig = plt.figure(figsize=(11, 14))
     grid = AxesGrid(fig, 111,
         axes_class=(GeoAxes, dict(projection=ccrs.PlateCarree())),
@@ -60,7 +61,7 @@ def plot_sst_eval(pp_root):
     )
 
     # Discrete levels and colorbar for SST plots
-    levels = np.arange(2, 31, 2)
+    levels = np.arange(config['levels_min'], config['levels_max'], config['levels_step'])
     try:
         import cmcrameri.cm as cmc
     except ModuleNotFoundError:
@@ -70,7 +71,7 @@ def plot_sst_eval(pp_root):
     cmap, norm = get_map_norm(cmap, levels=levels)
 
     # Discrete levels and colorbar for difference plots
-    bias_levels = np.arange(-2, 2.1, 0.25)
+    bias_levels = np.arange(config['bias_min'], config['bias_max'], config['bias_step'])
     bias_cmap, bias_norm = get_map_norm('coolwarm', levels=bias_levels)
     bias_common = dict(cmap=bias_cmap, norm=bias_norm)
 
@@ -104,8 +105,8 @@ def plot_sst_eval(pp_root):
     annotate_skill(model_ave, glorys_rg, grid[5], weights=model_grid.areacello)
 
     for ax in grid:
-        ax.set_xlim(-99, -35)
-        ax.set_ylim(4, 59)
+        ax.set_xlim(config['x']['min'], config['x']['max'])
+        ax.set_ylim(config['y']['min'], config['y']['max'])
         ax.set_xticks([])
         ax.set_yticks([])
         ax.set_xticklabels([])
@@ -113,12 +114,16 @@ def plot_sst_eval(pp_root):
         for s in ax.spines.values():
             s.set_visible(False)
         
-    plt.savefig('figures/sst_eval.png', dpi=300, bbox_inches='tight')
+    plt.savefig(config['figures_dir']+'sst_eval.png', dpi=300, bbox_inches='tight')
 
 
 if __name__ == '__main__':
     from argparse import ArgumentParser
+    import yaml
     parser = ArgumentParser()
-    parser.add_argument('pp_root', help='Path to postprocessed data (up to but not including /pp/)')
+    parser.add_argument('-p','--pp_root', type=str, help='Path to postprocessed data (up to but not including /pp/)')
+    parser.add_argument('-c','--config', type=str, help='Path to config.yaml file containing relevant paths for diagnostic scripts')
     args = parser.parse_args()
-    plot_sst_eval(args.pp_root)
+    with open(args.config, 'r') as f:
+        config = yaml.safe_load(f)
+    plot_sst_eval(args.pp_root, config)

--- a/diagnostics/physics/sst_eval.py
+++ b/diagnostics/physics/sst_eval.py
@@ -18,6 +18,7 @@ from plot_common import annotate_skill, autoextend_colorbar, corners, get_map_no
 
 
 def plot_sst_eval(pp_root, config):
+    
     model = open_var(pp_root, config['domain'], 'tos')
     model_grid = xarray.open_dataset( config['model_grid'] )
     target_grid = model_grid[config['rename_map'].keys()].rename(config['rename_map'])
@@ -26,8 +27,11 @@ def plot_sst_eval(pp_root, config):
     glorys = xarray.open_dataset( config['glorys'] ).squeeze(drop=True)['thetao'] #.rename({'longitude': 'lon', 'latitude': 'lat'})
     try:
         glorys_lonc, glorys_latc = corners(glorys.lon, glorys.lat)
-    except:
+    except AttributeError:
         glorys_lonc, glorys_latc = corners(glorys.longitude, glorys.latitude)
+    else:
+        raise Exception("Error: Lat/Latitude, Lon/Longitdue not found in glorys data")
+
     glorys_ave = glorys.mean('time').load()
     glorys_to_mom = xesmf.Regridder(glorys_ave, target_grid, method='bilinear', unmapped_to_nan=True)
     glorys_rg = glorys_to_mom(glorys_ave)

--- a/diagnostics/physics/sst_eval.py
+++ b/diagnostics/physics/sst_eval.py
@@ -138,8 +138,8 @@ def plot_sst_eval(pp_root, config):
 if __name__ == '__main__':
     from argparse import ArgumentParser
     parser = ArgumentParser()
-    parser.add_argument('-p','--pp_root', type=str, help='Path to postprocessed data (up to but not including /pp/)')
-    parser.add_argument('-c','--config', type=str, help='Path to config.yaml file containing relevant paths for diagnostic scripts')
+    parser.add_argument('-p','--pp_root', type=str, help='Path to postprocessed data (up to but not including /pp/)', required=True)
+    parser.add_argument('-c','--config', type=str, help='Path to config.yaml file containing relevant paths for diagnostic scripts', required=True)
     args = parser.parse_args()
     config = load_config(args.config)
     plot_sst_eval(args.pp_root, config)


### PR DESCRIPTION
This pull request adds a config.yaml file to the physics diagnostics directory to make it easier to run the diagnostics scripts across domains by removing hardcoded variables. As a first test for the new config file, this PR also modifies the sst_eval.py script to use variables supplied by the config file. The script produces the same output as before for the NWA domain, but it can now be used across other domains as well by modifying the variables within the config file. Below is are the outputs from the script in the NWA and NEP domains using the new config file 

![sst_eval](https://github.com/user-attachments/assets/4994ec06-7b51-4495-a096-886907c8ec31)
![sst_eval_nep_align](https://github.com/user-attachments/assets/428651d9-212f-44bf-ab33-f7101c9b5424)
![sst_eval_better_lims](https://github.com/user-attachments/assets/74a567b2-d884-47fe-873f-9d682a0e9ad1)
![sst_eval_arctic](https://github.com/user-attachments/assets/0364c2d8-9b10-4e5c-8c11-24d8b88a2da3)

