### PR TITLE
Temporal solution for data transfer on C6

### DIFF
--- a/xmls/NWA12/CEFI_NWA12_cobalt.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt.xml
@@ -9,7 +9,7 @@ On GFDL Analysis:
 module load fre/test
 
 On Gaea:
-module use -a /ncrc/home2/fms/local/modulefiles
+module use -a /ncrc/home2/Yi-cheng.Teng/local/modulefiles
 module load fre/test
 
 Compile and build mom6-sis2-cobalt:

--- a/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
@@ -9,7 +9,7 @@ On GFDL Analysis:
 module load fre/test
 
 On Gaea:
-module use -a /ncrc/home2/fms/local/modulefiles
+module use -a /ncrc/home2/Yi-cheng.Teng/local/modulefiles
 module load fre/test
 
 Compile and build mom6-sis2-cobalt:

--- a/xmls/NWA12/analysis/cefi_bgc_monthly.csh
+++ b/xmls/NWA12/analysis/cefi_bgc_monthly.csh
@@ -67,7 +67,7 @@ endif
 source $MODULESHOME/init/csh
 module use -a /home/fms/local/modulefiles
 module purge
-module load fre/bronx-21
+module load fre/test
 module load gcp
 module load git
 module use -a /home/ynt/modulefiles

--- a/xmls/NWA12/analysis/cefi_physics_monthly.csh
+++ b/xmls/NWA12/analysis/cefi_physics_monthly.csh
@@ -68,7 +68,7 @@ endif
 source $MODULESHOME/init/csh
 module use -a /home/fms/local/modulefiles
 module purge
-module load fre/bronx-21
+module load fre/test
 module load gcp
 module load git
 module use -a /home/ynt/modulefiles


### PR DESCRIPTION
Following the recent maintenance, the `dtn_f5_f6` partition appears to be malfunctioning on C6, which has caused data transfer issue for users attempting to load `fre/test` and run the FRE workflow on C6. To mitigate this, I’ve created a temporary version of `fre/test` with a hotfix (use `rdtn_c5` and `rdtn_c5` instead) in my home directory to ensure that we can continue our work on C6 without disruption.

FYI @andrew-c-ross , @charliestock , @gabyneg , @theresa-morrison , @uwagura 