### PR TITLE
Fixed uv rotation

### DIFF
--- a/tools/boundary/boundary.py
+++ b/tools/boundary/boundary.py
@@ -20,7 +20,7 @@ def rotate_uv(u, v, angle):
     Args:
         u: west-east component of velocity.
         v: south-north component of velocity.
-        angle: angle of rotation from true north to model north.
+        angle: angle of rotation from true north to model north (defined in a counterclockwise direction).
 
     Returns:
         Model-relative west-east and south-north components of velocity.

--- a/tools/boundary/boundary.py
+++ b/tools/boundary/boundary.py
@@ -25,8 +25,8 @@ def rotate_uv(u, v, angle):
     Returns:
         Model-relative west-east and south-north components of velocity.
     """
-    urot = np.cos(angle) * u + np.sin(angle) * v
-    vrot = -np.sin(angle) * u + np.cos(angle) * v
+    urot = np.cos(angle) * u - np.sin(angle) * v
+    vrot = np.sin(angle) * u + np.cos(angle) * v
     return urot, vrot
 
 


### PR DESCRIPTION
We identified a bug in our Python pre-processing tool related to the sign of the UV rotation. The sign was incorrect, so we have reversed it and verified the fix in both the `NEP` and `ARCTIC` domains (see figures below; the black arrow represents true north, the green indicates the previous rotation, and the red shows the corrected rotation). The updated rotation should now accurately map the Earth’s true UV coordinates to the model’s coordinate system.

`NEP`:
![nep_test](https://github.com/user-attachments/assets/88656bf2-1a0a-484d-bdba-f80aeb3064bd)

`ARC`:
![arc_test](https://github.com/user-attachments/assets/3460ad46-b38e-4b0f-9c88-e64291020a84)
