### PR TITLE
Generalize sst_trends

### DIFF
--- a/diagnostics/physics/config.yaml
+++ b/diagnostics/physics/config.yaml
@@ -65,4 +65,13 @@ levels_step: 2
 # Colorbar for sst difference plots
 bias_min: -2
 bias_max: 2.1
+bias_min_trends: -1.5
+bias_max_trends: 1.51
 bias_step: 0.25
+
+ticks: [-2, -1, 0, 1, 2]
+
+
+# SST Trends Settings
+start_year: "2005"
+end_year: "2019"

--- a/diagnostics/physics/plot_common.py
+++ b/diagnostics/physics/plot_common.py
@@ -176,8 +176,7 @@ def load_config(config_path: str):
         logger.error(f"Error loading configuration from {config_path}: {e}")
         raise
 
-def process_oisst(config, target_grid, model_ave, start=1993, end = 2020, resamp_freq = None, do_regrid=True
-    ) -> ( (xesmf.Regridder | xarray.DataArray), xarray.DataArray, xarray.DataArray, xarray.DataArray ):
+def process_oisst(config, target_grid, model_ave, start=1993, end = 2020, resamp_freq = None):
     """Open and regrid OISST dataset, return relevant vars from dataset."""
     try:
         oisst = (
@@ -209,17 +208,13 @@ def process_oisst(config, target_grid, model_ave, start=1993, end = 2020, resamp
 
     oisst_ave = oisst.mean('time')
 
-    # Either apply the regridder to the average, or return the regrid object itself
-    if do_regrid:
-        mom_rg = mom_to_oisst(model_ave)
-        logger.info("OISST data processed successfully.")
-        return mom_rg, oisst_ave, oisst_lonc, oisst_latc
-
-    return mom_to_oisst, oisst_ave, oisst_lonc, oisst_latc
+    mom_rg = mom_to_oisst(model_ave)
+    logger.info("OISST data processed successfully.")
+    return mom_rg, oisst_ave, oisst_lonc, oisst_latc
 
 def process_glorys(
     config, target_grid, var, sel_time = None, resamp_freq = None, do_regrid=True
-    ) ->  ( (xesmf.Regridder | xarray.DataArray), xarray.DataArray, xarray.DataArray, xarray.DataArray ):
+        ) ->  ( (xesmf.Regridder | xarray.DataArray), xarray.DataArray, xarray.DataArray, xarray.DataArray ):
     """ Open and regrid glorys data, return regridded glorys data """
     glorys = xarray.open_dataset( config['glorys'] ).squeeze(drop=True) #.rename({'longitude': 'lon', 'latitude': 'lat'})
     if var in glorys:
@@ -259,6 +254,7 @@ def process_glorys(
         return glorys_rg, glorys_ave, glorys_lonc, glorys_latc
 
     return glorys_to_mom, glorys_ave, glorys_lonc, glorys_latc
+
 
 def get_end_of_climatology_period(clima_file):
     """

--- a/diagnostics/physics/plot_common.py
+++ b/diagnostics/physics/plot_common.py
@@ -215,7 +215,9 @@ def process_oisst(config, target_grid, model_ave, start=1993, end = 2020, resamp
 
     return mom_to_oisst, oisst_ave, oisst_lonc, oisst_latc
 
-def process_glorys(config, target_grid, var, sel_time = None, resamp_freq = None, do_regrid=True):
+def process_glorys(
+    config, target_grid, var, sel_time = None, resamp_freq = None, do_regrid=True
+    ) ->  ( (xesmf.Regridder | xarray.DataArray), xarray.DataArray, xarray.DataArray, xarray.DataArray ):
     """ Open and regrid glorys data, return regridded glorys data """
     glorys = xarray.open_dataset( config['glorys'] ).squeeze(drop=True) #.rename({'longitude': 'lon', 'latitude': 'lat'})
     if var in glorys:

--- a/diagnostics/physics/plot_common.py
+++ b/diagnostics/physics/plot_common.py
@@ -225,7 +225,7 @@ def process_glorys(config, target_grid, var):
         logger.info("Glorys data is using longitude/latitude")
     except:
         logger.error("Name of longitude and latitude variables is unknown")
-        raise Exception("Error: Lat/Latitude, Lon/Longitdue not found in glorys data")
+        raise Exception("Error: Lat/Latitude, Lon/Longitude not found in glorys data")
 
     glorys_ave = glorys.mean('time').load()
     glorys_to_mom = xesmf.Regridder(glorys_ave, target_grid, method='bilinear', unmapped_to_nan=True)

--- a/diagnostics/physics/sst_trends.py
+++ b/diagnostics/physics/sst_trends.py
@@ -53,16 +53,14 @@ def plot_sst_trends(pp_root, label, config):
     target_grid = model_grid[ config['rename_map'].keys() ].rename( config['rename_map'] )
 
     # Process OISST and get trend
-    mom_to_oisst, oisst, oisst_lonc, oisst_latc = process_oisst(config, target_grid, model, start =  int(config['start_year']),
-                                                                end = int(config['end_year'])+1, resamp_freq = '1AS',
-                                                                do_regrid = False) # (note that model data is not used if do_regrid = False)
+    mom_rg, oisst, oisst_lonc, oisst_latc = process_oisst(config, target_grid, model_trend, start =  int(config['start_year']),
+                                                                end = int(config['end_year'])+1, resamp_freq = '1AS')
     logger.info("OISST: %s", oisst )
     oisst_trend = get_3d_trends(oisst['time.year'], oisst) * 10 # -> C / decade
     oisst_trend = xarray.DataArray(oisst_trend, dims=['lat','lon'], coords={'lat':oisst.lat,'lon':oisst.lon} )
     logger.info("OISST_TREND: %s",oisst_trend)
 
-    mom_rg = mom_to_oisst(model_trend)
-    mom_rg = xarray.DataArray(mom_rg, dims = ['lat','lon'], coords = {'lat':oisst.lat, 'lon':oisst.lon} )
+    #mom_rg = xarray.DataArray(mom_rg, dims = ['lat','lon'], coords = {'lat':oisst.lat, 'lon':oisst.lon} )
     oisst_delta = mom_rg - oisst_trend
     logger.info("MOM_RG: %s",mom_rg)
     logger.info("OISST_DELTA: %s",oisst_delta)
@@ -70,7 +68,7 @@ def plot_sst_trends(pp_root, label, config):
     # Process Glorys and get trend
     glorys_to_mom , glorys, glorys_lonc, glorys_latc = process_glorys(config, target_grid, 'thetao',
                                                                       sel_time = slice(config['start_year'], config['end_year']),
-                                                                      resamp_freq = '1AS', do_regrid=False)
+                                                                      resamp_freq = '1AS', do_regrid = False)
     glorys_trend = get_3d_trends(glorys['time.year'], glorys) * 10 # -> C / decade
     logger.info("GLORYS_TREND: %s",glorys_trend)
 

--- a/diagnostics/physics/sst_trends.py
+++ b/diagnostics/physics/sst_trends.py
@@ -50,7 +50,7 @@ def plot_sst_trends(pp_root, label, config):
     model_trend = xarray.DataArray(model_trend, dims=['yh', 'xh'], coords={'yh': model.yh, 'xh': model.xh})
     logger.info("MODEL_TREND: %s", model_trend)
 
-    target_grid = model_grid[['geolon', 'geolat']].rename({'geolon': 'lon', 'geolat': 'lat'})
+    target_grid = model_grid[ config['rename_map'].keys() ].rename( config['rename_map'] )
 
     # Process OISST and get trend
     mom_to_oisst, oisst, oisst_lonc, oisst_latc = process_oisst(config, target_grid, model, start =  int(config['start_year']),

--- a/diagnostics/physics/sst_trends.py
+++ b/diagnostics/physics/sst_trends.py
@@ -20,11 +20,12 @@ from plot_common import( autoextend_colorbar, corners, get_map_norm,
 logger = logging.getLogger(__name__)
 logging.basicConfig(filename="sst_trends.log", format='%(asctime)s %(levelname)s:%(name)s: %(message)s',level=logging.INFO)
 
-def get_3d_trends(x, y):
-    x = np.array(x)
+def get_3d_trends(y):
+    x = np.array( y['time.year'] )
     y2 = np.array(y).reshape((len(x), -1))
     coefs = np.polyfit(x, y2, 1)
-    trends = coefs[0, :].reshape(y.shape[1:])
+    trends = coefs[0, :].reshape(y.shape[1:]) * 10 # -> C / decade
+
     return trends
 
 
@@ -45,7 +46,7 @@ def plot_sst_trends(pp_root, label, config):
     model = xarray.align(model_grid, model, join='override', exclude='time')[1]
     logger.info("Successfully modified coordinates of model grid, and aligned model coordinates to grid coordinates")
 
-    model_trend = get_3d_trends(model['time.year'], model) * 10 # -> C / decade
+    model_trend = get_3d_trends(model)
     # Convert to Data Array, since xskillscore expects dataarrays to calculate skill metrics
     model_trend = xarray.DataArray(model_trend, dims=['yh', 'xh'], coords={'yh': model.yh, 'xh': model.xh})
     logger.info("MODEL_TREND: %s", model_trend)
@@ -56,23 +57,21 @@ def plot_sst_trends(pp_root, label, config):
     mom_rg, oisst, oisst_lonc, oisst_latc = process_oisst(config, target_grid, model_trend, start =  int(config['start_year']),
                                                                 end = int(config['end_year'])+1, resamp_freq = '1AS')
     logger.info("OISST: %s", oisst )
-    oisst_trend = get_3d_trends(oisst['time.year'], oisst) * 10 # -> C / decade
+    oisst_trend = get_3d_trends(oisst)
     oisst_trend = xarray.DataArray(oisst_trend, dims=['lat','lon'], coords={'lat':oisst.lat,'lon':oisst.lon} )
     logger.info("OISST_TREND: %s",oisst_trend)
 
-    #mom_rg = xarray.DataArray(mom_rg, dims = ['lat','lon'], coords = {'lat':oisst.lat, 'lon':oisst.lon} )
     oisst_delta = mom_rg - oisst_trend
     logger.info("MOM_RG: %s",mom_rg)
     logger.info("OISST_DELTA: %s",oisst_delta)
 
     # Process Glorys and get trend
-    glorys_to_mom , glorys, glorys_lonc, glorys_latc = process_glorys(config, target_grid, 'thetao',
+    # NOTE: Glorys_ave is glorys_trends because we call get_3d_trends on it.
+    glorys_rg, glorys_trend, glorys_lonc, glorys_latc = process_glorys(config, target_grid, 'thetao',
                                                                       sel_time = slice(config['start_year'], config['end_year']),
-                                                                      resamp_freq = '1AS', do_regrid = False)
-    glorys_trend = get_3d_trends(glorys['time.year'], glorys) * 10 # -> C / decade
+                                                                      resamp_freq = '1AS', preprocess_regrid = get_3d_trends)
     logger.info("GLORYS_TREND: %s",glorys_trend)
 
-    glorys_rg = glorys_to_mom(glorys_trend)
     glorys_rg = xarray.DataArray(glorys_rg, dims=['yh', 'xh'], coords={'yh': model.yh, 'xh': model.xh})
     glorys_delta = model_trend - glorys_rg
     logger.info("GLORYS_RG: %s",glorys_rg)


### PR DESCRIPTION
This PR adds the ability to run `sst_trends.py` using the config.yaml file. As always, figures of the new output are attached below, and I wouldn't read too much into any of actual metrics.

I added options to the `process_glorys` function in  `plot_common` to work with script. You can now optionally specify a resample frequency that will be applied to the dataset before take the mean, as well as the whether you want to return the regrid object or the regridded glorys data. These options make the function compatible with this script, but I wasn't sure if the regrid option was good design, since it means that 'process_glorys' now technically has two different return values. I added type hints to reflect this, but I would love to hear people's opinions on this design and whether or not I should revert `process_glorys` to a single return type and avoid calling it in this script. 

Similarly, I avoided calling `process_oisst` in this script because 1.) it regrids model output to the oisst data, while `sst_trends` regrids oisst data to the model output and 2.) it uses a conservative normed method to regrid, while `sst_trends` uses a bilinear method. It's probably possible to add options to `process_oisst` to handle these differences, but it would complicate the logic in `process_oisst` a bit more (especially if I added the two new options from `process_glorys` as well) , so I thought I'd open these changes to discussion as well before implementing them. 

![sst_trends_arctic](https://github.com/user-attachments/assets/da51520e-c80d-49c7-a12f-bb8286e78021)
![sst_trends_MHI](https://github.com/user-attachments/assets/7452f73d-d3d8-407e-9e0c-17081f5a576e)
![sst_trends_nep](https://github.com/user-attachments/assets/5f509db3-e046-41c3-8f0c-cfdff8364423)
![sst_trends_nwa](https://github.com/user-attachments/assets/d3577668-7968-4de1-8455-6f35f3fdec44)
