### PR TITLE
Update ncrc5.intel23.env

### DIFF
--- a/builds/gaea/ncrc5.intel23.env
+++ b/builds/gaea/ncrc5.intel23.env
@@ -1,10 +1,14 @@
 source $MODULESHOME/init/tcsh
+module unload darshan-runtime
+module unload cray-libsci
 module unload cray-netcdf cray-hdf5 fre
 module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
 module load PrgEnv-intel/8.5.0
 module unload intel intel-classic intel-oneapi
+module load cray-hdf5-parallel/1.14.3.1
 module load intel-classic/2023.2.0
+module load fre/bronx-22
 module load cray-hdf5/1.12.2.11
-module load cray-netcdf/4.9.0.9
+module load libyaml/0.2.5
 module list
 ftn --version

--- a/builds/gaea/ncrc5.intel23.env
+++ b/builds/gaea/ncrc5.intel23.env
@@ -1,11 +1,10 @@
 source $MODULESHOME/init/tcsh
 module unload cray-netcdf cray-hdf5 fre
 module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
-module load PrgEnv-intel/8.3.3
+module load PrgEnv-intel/8.5.0
 module unload intel intel-classic intel-oneapi
-module load intel-classic/2023.1.0
-module load cray-hdf5/1.12.2.3
-module load cray-netcdf/4.9.0.3
-module load libyaml/0.2.5
+module load intel-classic/2023.2.0
+module load cray-hdf5/1.12.2.11
+module load cray-netcdf/4.9.0.9
 module list
 ftn --version

--- a/builds/gaea/ncrc6.intel23.env
+++ b/builds/gaea/ncrc6.intel23.env
@@ -1,4 +1,6 @@
 source $MODULESHOME/init/tcsh
+module unload darshan-runtime
+module unload cray-libsci
 module unload cray-netcdf cray-hdf5 fre
 module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
 module load PrgEnv-intel/8.5.0

--- a/exps/NWA12.COBALT/driver.sh
+++ b/exps/NWA12.COBALT/driver.sh
@@ -22,12 +22,19 @@ pushd ../
 ln -fs /gpfs/f6/ira-cefi/world-shared/datasets ./
 popd
 
+#
+echo "clean RESTART folders ..."
+rm -rf /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_48hrs/*
+rm -rf /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_24hrs/*
+rm -rf /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_24hrs_rst/*
+
 echo "run 30x30 48hrs test ..."
 ln -fs input.nml_48hr input.nml
 pushd INPUT/
 ln -fs MOM_layout_30 MOM_layout
 ln -fs MOM_layout_30 SIS_layout
 popd
+ln -fs /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_48hrs ./RESTART
 srun --ntasks ${ntasks1} --cpus-per-task=1 --export=ALL ../../builds/build/gaea-ncrc6.intel23/ocean_ice/repro/MOM6SIS2 > out1 2>err1
 mv RESTART RESTART_48hrs
 mv ocean.stats RESTART_48hrs
@@ -35,6 +42,7 @@ mv ocean.stats RESTART_48hrs
 #
 echo "run 30x30 24hrs test ..."
 ln -fs input.nml_24hr input.nml
+ln -fs /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_24hrs ./RESTART
 srun --ntasks ${ntasks1} --cpus-per-task=1 --export=ALL ../../builds/build/gaea-ncrc6.intel23/ocean_ice/repro/MOM6SIS2 > out2 2>err2
 mv RESTART RESTART_24hrs
 mv ocean.stats RESTART_24hrs
@@ -52,6 +60,7 @@ pushd INPUT/
 ln -fs MOM_layout_25 MOM_layout
 ln -fs MOM_layout_25 SIS_layout
 popd
+ln -fs /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_24hrs_rst ./RESTART
 srun --ntasks ${ntasks2} --cpus-per-task=1 --export=ALL ../../builds/build/gaea-ncrc6.intel23/ocean_ice/repro/MOM6SIS2 > out3 2>err3
 mv RESTART RESTART_24hrs_rst
 mv ocean.stats RESTART_24hrs_rst
@@ -75,4 +84,11 @@ done
 
 #
 echo "All restart files are identical, PASS"
+
+#
+echo "clean RESTART folders now ..."
+rm -rf /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_48hrs/*
+rm -rf /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_24hrs/*
+rm -rf /gpfs/f6/ira-cefi/proj-shared/github/tmp/NEP10/RESTART_24hrs_rst/*
+
 echo "Test ended:  " `date`

--- a/xmls/NWA12/CEFI_NWA12_cobalt.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt.xml
@@ -102,8 +102,8 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
   <property name="append_to_setup_csh" value="set fyear=`echo $baseDate | cut -c1-4`"/>
 
   <setup>
-    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc5.intel22'])"/>
-    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc5-intel22'])"/>
+    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc5.intel23'])"/>
+    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc5-intel23'])"/>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc6.intel23'])"/>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel23'])"/>
   </setup>

--- a/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
@@ -102,8 +102,8 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt_fms2_yaml.xml CEFI_NWA1
   <property name="append_to_setup_csh" value="set fyear=`echo $baseDate | cut -c1-4`"/>
 
   <setup>
-    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc5.intel22'])"/>
-    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc5-intel22'])"/>
+    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc5.intel23'])"/>
+    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc5-intel23'])"/>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc6.intel23'])"/>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel23'])"/>    
   </setup>

--- a/xmls/xml_include/xml_building_blocks/platforms.xml
+++ b/xmls/xml_include/xml_building_blocks/platforms.xml
@@ -96,7 +96,7 @@
     ]]>
     </csh>
   </platform>
-  <platform name="gfdl.ncrc5-intel22">
+  <platform name="gfdl.ncrc5-intel23">
     <xi:include xpointer="xpointer(//freInclude/platform[@name='gfdl.default']/node())" />
   </platform>
   <platform name="gfdl.ncrc6-intel23">

--- a/xmls/xml_include/xml_building_blocks/platforms.xml
+++ b/xmls/xml_include/xml_building_blocks/platforms.xml
@@ -1,7 +1,7 @@
 <freInclude xmlns:xi="http://www.w3.org/2003/XInclude">
-  <platform name="ncrc5.intel22">
+  <platform name="ncrc5.intel23">
     <freVersion>$(FRE_VERSION)</freVersion>
-    <compiler type="intel-classic" version="2022.0.2"/>
+    <compiler type="intel-classic" version="2023.2.0"/>
     <project>$(NCRC_GROUP)</project>
     <directory stem="$(FRE_STEM)">
       <root>/gpfs/f5/$(project)/scratch/$USER/$(stem)</root>


### PR DESCRIPTION
As stated in the title, C5 has updated its default Intel compiler and libraries. This PR reflects these change. Additionally, we fixed the FMS1 build on C6 and refactor NWA12 driver.sh for GHA CI.

