### PR TITLE
remove  cray-hdf5-parallel from ncrc5.intel23.env

### DIFF
--- a/builds/gaea/ncrc5.intel23.env
+++ b/builds/gaea/ncrc5.intel23.env
@@ -5,7 +5,6 @@ module unload cray-netcdf cray-hdf5 fre
 module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
 module load PrgEnv-intel/8.5.0
 module unload intel intel-classic intel-oneapi
-module load cray-hdf5-parallel/1.14.3.1
 module load intel-classic/2023.2.0
 module load fre/bronx-22
 module load cray-hdf5/1.12.2.11


### PR DESCRIPTION
As titled,  the `cray-hdf5-parallel` module is unnecessary and should be removed from `ncrc5.intel23.env`; otherwise, the build process on C5 will fail.