### PR TITLE
Updated MOM6 tag so now we can do bgc sponge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,11 +38,11 @@
 	path = src/coupler
 	url = https://github.com/NOAA-GFDL/FMScoupler.git
 	branch = 2024.03
-[submodule "src/MOM6"]
-	path = src/MOM6
-	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/MOM6.git
-	branch = dev/cefi
 [submodule "src/ocean_BGC"]
 	path = src/ocean_BGC
 	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
+	branch = dev/cefi
+[submodule "src/MOM6"]
+	path = src/MOM6
+	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/MOM6.git
 	branch = dev/cefi


### PR DESCRIPTION
As titled. Since MOM6 PR [#20 ](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/MOM6/pull/20) is merged. Now we can do Generic Tracer Sponges in COBALT. Brief instruction can be found [here](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/MOM6/pull/17).