### PR TITLE
Fix Paths on C5

### DIFF
--- a/xmls/NEP10/CEFI_NEP_cobalt.xml
+++ b/xmls/NEP10/CEFI_NEP_cobalt.xml
@@ -63,6 +63,7 @@ frecheck -v -r restart -p ncrc6.intel23 -t repro  -x CEFI_NEP_cobalt.xml CEFI_NE
   <!-- NCRC_GROUP will only have impact for your root dir and work dir on gaea c5/c6-->
   <!-- You have to either use -A or go to xml_include/xml_building_blocks/platforms.xml to change project for your project allocation-->
   <property name="NCRC_GROUP" value="ira-cefi"/>
+  <property name="NCRC_GROUP_C5" value="cefi"/>
   <property name="GFDL_GROUP" value="cefi"/>
 
   <!--Production run properties. Users can modify these according to their need and/or performance analysis-->

--- a/xmls/NWA12/CEFI_NWA12_cobalt.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt.xml
@@ -56,6 +56,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
 
   <!-- Please make sure to change your group, such as b, f, g, m, o... -->
   <property name="NCRC_GROUP" value="ira-cefi"/>
+  <property name="NCRC_GROUP_C5" value="cefi"/>
   <property name="GFDL_GROUP" value="cefi"/>
 
   <!--Production run properties. Users can modify these according to their need and/or performance analysis-->

--- a/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
@@ -56,6 +56,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt_fms2_yaml.xml CEFI_NWA1
 
   <!-- Please make sure to change your group, such as b, f, g, m, o... -->
   <property name="NCRC_GROUP" value="ira-cefi"/>
+  <property name="NCRC_GROUP_C5" value="cefi"/>
   <property name="GFDL_GROUP" value="cefi"/>
 
   <!--Production run properties. Users can modify these according to their need and/or performance analysis-->

--- a/xmls/xml_include/xml_building_blocks/platforms.xml
+++ b/xmls/xml_include/xml_building_blocks/platforms.xml
@@ -2,7 +2,7 @@
   <platform name="ncrc5.intel23">
     <freVersion>$(FRE_VERSION)</freVersion>
     <compiler type="intel-classic" version="2023.2.0"/>
-    <project>$(NCRC_GROUP)</project>
+    <project>$(NCRC_GROUP_C5)</project>
     <directory stem="$(FRE_STEM)">
       <root>/gpfs/f5/$(project)/scratch/$USER/$(stem)</root>
       <scripts>$(rootDir)/$(name)/$(platform)-$(target)/scripts</scripts>


### PR DESCRIPTION
This PR adds a new variable to all xmls so that that when models are run on c5, they point to t`/gpfs/f5/cefi` instead of `/gpfs/f5/ira-cefi`. I used a new variable as opposed to just using the `GFDL_GROUP` variable for clarity, but if we don't think the new variable is necessary that should be fine as well