### PR TITLE
Added stderr for obc gen scripts

### DIFF
--- a/tools/boundary/glorys_obc_workflow/template/fill_glorys_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/fill_glorys_template.sh
@@ -5,6 +5,7 @@
 #SBATCH --mail-type={{ _EMAIL_NOTIFACTION }}
 #SBATCH --mail-user={{ _USER_EMAIL }}
 #SBATCH --output={{ _LOG_PATH }}
+#SBATCH --error={{ _LOG_PATH }}
 
 # Usage: sbatch fill_glorys.sh <YEAR> <MONTH> <DAY>
 # This script is used to fill the GLORYS reanalysis data on GFDL PPAN

--- a/tools/boundary/glorys_obc_workflow/template/ncrcat_obc_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/ncrcat_obc_template.sh
@@ -4,7 +4,8 @@
 #SBATCH --ntasks={{ _NPROC }}
 #SBATCH --mail-type={{ _EMAIL_NOTIFACTION }}
 #SBATCH --mail-user={{ _USER_EMAIL }}
-#SBATCH --output=./log/%x.o%j
+#SBATCH --output={{ _LOG_PATH }}
+#SBATCH --error={{ _LOG_PATH }}
 
 # Usage: sbatch ncrcat_obc.sh <ncrcat_arg>
 # This script is used to submit sbatch jobs for concatenating daily obc file on GFDL PPAN

--- a/tools/boundary/glorys_obc_workflow/template/submit_python_make_obc_day_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/submit_python_make_obc_day_template.sh
@@ -5,6 +5,7 @@
 #SBATCH --mail-type={{ _EMAIL_NOTIFACTION }}
 #SBATCH --mail-user={{ _USER_EMAIL }}
 #SBATCH --output={{ _LOG_PATH }}
+#SBATCH --error={{ _LOG_PATH }}
 
 # Usage: sbatch submit_python_make_obc_day.sh <YEAR> <MONTH> <DAY>
 # This script is used to submit sbatch jobs for daily GLORYS OBC file generation on GFDL PPAN

--- a/tools/boundary/glorys_obc_workflow/template/subset_glorys_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/subset_glorys_template.sh
@@ -5,6 +5,7 @@
 #SBATCH --mail-type={{ _EMAIL_NOTIFACTION }}
 #SBATCH --mail-user={{ _USER_EMAIL }}
 #SBATCH --output={{ _LOG_PATH }}
+#SBATCH --error={{ _LOG_PATH }}
 
 # Usage: sbatch subset_glorys.sh <YEAR> <MONTH> <DAY>
 


### PR DESCRIPTION
As titled, we added `stderr` support to all `OBC_workflow` generation scripts to provide clearer logs when errors occur.