### PR TITLE
Improve timestamp adjustment function in Glorys obc generation workflow

### DIFF
--- a/tools/boundary/boundary.py
+++ b/tools/boundary/boundary.py
@@ -496,7 +496,8 @@ class Segment():
     def regrid_velocity(
                 self, usource, vsource, 
                 method='nearest_s2d', periodic=False, write=True, 
-                flood=False, fill='b', xdim='lon', ydim='lat', zdim='z', rotate=True, **kwargs):
+                flood=False, fill='b', xdim='lon', ydim='lat', zdim='z', rotate=True, 
+                time_attrs=None, time_encoding=None, **kwargs):
         """Interpolate velocity onto segment and (optionally) write to file.
 
         Args:
@@ -607,6 +608,12 @@ class Segment():
 
         ds_uv = self.rename_dims(ds_uv)
 
+        # Restore time attributes and encoding
+        if time_attrs:
+            ds_uv['time'].attrs = time_attrs
+        if time_encoding:
+            ds_uv['time'].encoding = time_encoding
+
         if write:
             self.to_netcdf(ds_uv, 'uv', **kwargs)
         
@@ -616,7 +623,8 @@ class Segment():
             self, tsource, 
             method='nearest_s2d', periodic=False, write=True, 
             flood=False, fill='b', xdim='lon', ydim='lat', zdim='z',
-            regrid_suffix='t', source_var=None, **kwargs):
+            regrid_suffix='t', source_var=None, 
+            time_attrs=None, time_encoding=None, **kwargs):
         """Regrid a tracer onto segment and (optionally) write to file.
 
         Args:
@@ -685,6 +693,12 @@ class Segment():
         
         tdest = self.rename_dims(tdest)
         tdest = tdest.rename({name: f'{name}_{self.segstr}'})
+
+        # Restore time attributes and encoding
+        if time_attrs:
+            tdest['time'].attrs = time_attrs
+        if time_encoding:
+            tdest['time'].encoding = time_encoding
         
         if write:
             self.to_netcdf(tdest, name, **kwargs)

--- a/tools/boundary/write_glorys_boundary_daily.py
+++ b/tools/boundary/write_glorys_boundary_daily.py
@@ -93,16 +93,41 @@ def concatenate_files(nsegments, output_dir, variables, ncrcat_names, first_date
                 adjust_file_timestamps(output_file)
 
 def adjust_file_timestamps(file_path):
-    """Adjust timestamps for the first and last records in a file."""
-    with xarray.open_dataset(file_path) as ds:
-        if 'time' in ds:
-            time = ds['time'].copy()
-            adjusted_time = time.astype('datetime64[ns]')
-            
-            adjusted_time[0] = adjusted_time[0].dt.floor('D')
-            adjusted_time[-1] = adjusted_time[-1].dt.ceil('D')
+    """
+    Adjust timestamps for the first and last records in a file while preserving attributes and raw numerical format.
+    """
+    with xarray.open_dataset(file_path, decode_times=False) as ds:
+        # Explicitly load the dataset into memory to ovid lazy-loaded
+        ds.load()
 
-            ds = ds.assign_coords(time=adjusted_time)
+        if 'time' in ds:
+            # Extract the time variable, attributes, and encoding
+            time = ds['time']
+            time_attrs = time.attrs  # Save the original attributes
+            time_encoding = time.encoding  # Save the original encoding
+            time_values = time.values.copy()
+
+            # Ensure the 'time' variable has more than one entry
+            if len(time_values) > 1:
+                # Adjust the first and last timestamps in raw numerical format
+                time_values[0] = np.floor(time_values[0])  # Floor to the start of the day
+                time_values[-1] = np.ceil(time_values[-1])  # Ceil to the end of the day
+
+            # Create a new DataArray for time while preserving attributes
+            new_time = xarray.DataArray(
+                time_values,
+                dims=time.dims,
+                attrs=time_attrs,
+                name='time'
+            )
+
+            # Assign the new time variable back to the dataset
+            ds = ds.assign_coords(time=new_time)
+
+            # Reapply the original encoding
+            ds['time'].encoding = time_encoding
+
+            # Save the updated dataset
             ds.to_netcdf(file_path)
             print(f"Timestamps adjusted for {file_path}")
 


### PR DESCRIPTION
Several users have reported that the timestamp adjustment function in the current OBC workflow disrupts the original time variables and attributes, and will eventually mess up model run. This PR aims to address the issue by using `decode_times=False` when reading the files. Additionally, we have modified several boundary generation codes to further preserve the original time attributes and encoding.

**_UPDATES_**
I tested the updated workflow with the ARCTIC physics-only case shared by @theresa-morrison, and the new OBC files generated from it ran successfully through the year 1993.

The example obc generation workflow for Arctic can be found on ppan:
`/work/ynt/develop/20250124/new/CEFI-regional-MOM6/tools/boundary/glorys_obc_workflow/mom6_obc_workflow_arctic.sh `

The Arctic 1-month test case can be found here:
`/gpfs/f6/ira-cefi/proj-shared/ARC12_nofk_nsrwsp_newobcs__1.o207690353`