### PR TITLE
2025.01 update part.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,10 +30,6 @@
 	path = src/MOM6
 	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/MOM6.git
 	branch = dev/cefi
-[submodule "src/ocean_BGC"]
-	path = src/ocean_BGC
-	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
-	branch = dev/cefi
 [submodule "src/FMS"]
 	path = src/FMS
 	url = https://github.com/NOAA-GFDL/FMS.git
@@ -46,3 +42,7 @@
 	path = src/atmos_null
 	url = https://github.com/NOAA-GFDL/atmos_null.git
 	branch = 2025.01
+[submodule "src/ocean_BGC"]
+	path = src/ocean_BGC
+	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
+	branch = dev/cefi

--- a/exps/NEP10.COBALT/COBALT_parameter_doc.all
+++ b/exps/NEP10.COBALT/COBALT_parameter_doc.all
@@ -624,6 +624,8 @@ z_denit = 10.0                  !   [m] default = 10.0
                                 ! depth scale for ramping up benthic denitrification
 scale_burial = 0.0              !   [none] default = 0.0
                                 ! scaling factor for particulate organic burial
+do_fnso4red_sed = False         !   [Boolean] default = False
+                                ! logical flag to include O2 demand and alk impact of H2S- sediment release
 z_sed = 0.1                     !   [m] default = 0.1
                                 ! effective sediment layer thickness for calcite cycling calculations
 phi_surfresp_cased = 0.14307    !   [unitless] default = 0.14307
@@ -681,6 +683,8 @@ k_no3_amx = 1.0E-06             !   [mol NO3 kg-1] default = 1.0E-06
                                 ! nitrate half-saturation for anammox
 tracer_debug = False            !   [Boolean] default = False
                                 ! flag for tracer debug operations
+min_thickness_for_imbalance = 0.001 !   [m] default = 0.001
+                                ! minimum thickness of a layer that will be checked for source/sink imbalances
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/exps/NWA12.COBALT/COBALT_parameter_doc.all
+++ b/exps/NWA12.COBALT/COBALT_parameter_doc.all
@@ -624,6 +624,8 @@ z_denit = 20.0                  !   [m] default = 10.0
                                 ! depth scale for ramping up benthic denitrification
 scale_burial = 1.0              !   [none] default = 0.0
                                 ! scaling factor for particulate organic burial
+do_fnso4red_sed = False         !   [Boolean] default = False
+                                ! logical flag to include O2 demand and alk impact of H2S- sediment release
 z_sed = 0.1                     !   [m] default = 0.1
                                 ! effective sediment layer thickness for calcite cycling calculations
 phi_surfresp_cased = 0.14307    !   [unitless] default = 0.14307
@@ -681,6 +683,8 @@ k_no3_amx = 1.0E-06             !   [mol NO3 kg-1] default = 1.0E-06
                                 ! nitrate half-saturation for anammox
 tracer_debug = False            !   [Boolean] default = False
                                 ! flag for tracer debug operations
+min_thickness_for_imbalance = 0.001 !   [m] default = 0.001
+                                ! minimum thickness of a layer that will be checked for source/sink imbalances
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/exps/OM4.single_column.COBALT/COBALT_parameter_doc.all
+++ b/exps/OM4.single_column.COBALT/COBALT_parameter_doc.all
@@ -618,6 +618,8 @@ z_denit = 10.0                  !   [m] default = 10.0
                                 ! depth scale for ramping up benthic denitrification
 scale_burial = 0.0              !   [none] default = 0.0
                                 ! scaling factor for particulate organic burial
+do_fnso4red_sed = False         !   [Boolean] default = False
+                                ! logical flag to include O2 demand and alk impact of H2S- sediment release
 z_sed = 0.1                     !   [m] default = 0.1
                                 ! effective sediment layer thickness for calcite cycling calculations
 phi_surfresp_cased = 0.14307    !   [unitless] default = 0.14307
@@ -675,6 +677,8 @@ k_no3_amx = 1.0E-06             !   [mol NO3 kg-1] default = 1.0E-06
                                 ! nitrate half-saturation for anammox
 tracer_debug = False            !   [Boolean] default = False
                                 ! flag for tracer debug operations
+min_thickness_for_imbalance = 0.001 !   [m] default = 0.001
+                                ! minimum thickness of a layer that will be checked for source/sink imbalances
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/exps/OM4p25.COBALT/COBALT_parameter_doc.all
+++ b/exps/OM4p25.COBALT/COBALT_parameter_doc.all
@@ -618,6 +618,8 @@ z_denit = 10.0                  !   [m] default = 10.0
                                 ! depth scale for ramping up benthic denitrification
 scale_burial = 1.0              !   [none] default = 0.0
                                 ! scaling factor for particulate organic burial
+do_fnso4red_sed = False         !   [Boolean] default = False
+                                ! logical flag to include O2 demand and alk impact of H2S- sediment release
 z_sed = 0.1                     !   [m] default = 0.1
                                 ! effective sediment layer thickness for calcite cycling calculations
 phi_surfresp_cased = 0.14307    !   [unitless] default = 0.14307
@@ -675,6 +677,8 @@ k_no3_amx = 1.0E-06             !   [mol NO3 kg-1] default = 1.0E-06
                                 ! nitrate half-saturation for anammox
 tracer_debug = False            !   [Boolean] default = False
                                 ! flag for tracer debug operations
+min_thickness_for_imbalance = 0.001 !   [m] default = 0.001
+                                ! minimum thickness of a layer that will be checked for source/sink imbalances
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False


### PR DESCRIPTION
Part 2 updated the COBALT tag, which includes two new runtime parameters: `min_thickness_for_imbalance`, making the imbalance check more robust, and `do_fnso4red_sed`, a logical flag that accounts for O₂ demand and alkalinity impact from H₂S sediment release. The default for this parameter is false, preserving the current baseline answers.