### PR TITLE
2025.01 update part 3.1

### DIFF
--- a/exps/NEP10.COBALT/INPUT/MOM_input
+++ b/exps/NEP10.COBALT/INPUT/MOM_input
@@ -917,10 +917,7 @@ TIDE_P1 = True
 TIDE_Q1 = True
 TIDE_MM = True
 TIDE_MF = True
-TIDE_SAL_SCALAR_VALUE = 0.010   !   [m m-1]
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
+SAL_SCALAR_VALUE = 0.010   !   [m m-1]
 TIDE_USE_EQ_PHASE = True
 
 ! === module ocean_model_init ===

--- a/exps/NEP10.COBALT/MOM_parameter_doc.all
+++ b/exps/NEP10.COBALT/MOM_parameter_doc.all
@@ -1097,10 +1097,10 @@ SAL_USE_BPA = False             !   [Boolean] default = False
 SAL_SCALAR_APPROX = True        !   [Boolean] default = True
                                 ! If true, use the scalar approximation to calculate self-attraction and
                                 ! loading.
-SAL_SCALAR_VALUE = 0.01         !   [m m-1] default = 0.01
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if USE_SAL_SCALAR is true or USE_PREVIOUS_TIDES is true.
+SAL_SCALAR_VALUE = 0.01         !   [m m-1] default = 0.0
+                                ! The constant of proportionality between self-attraction and loading (SAL)
+                                ! geopotential anomaly and barotropic geopotential anomaly. This is only used if
+                                ! SAL_SCALAR_APPROX is true or USE_PREVIOUS_TIDES is true.
 SAL_HARMONICS = False           !   [Boolean] default = False
                                 ! If true, use the online spherical harmonics method to calculate
                                 ! self-attraction and loading.

--- a/exps/NEP10.COBALT/MOM_parameter_doc.short
+++ b/exps/NEP10.COBALT/MOM_parameter_doc.short
@@ -351,6 +351,10 @@ CORIOLIS_EN_DIS = True          !   [Boolean] default = False
                                 ! used.
 
 ! === module MOM_self_attr_load ===
+SAL_SCALAR_VALUE = 0.01         !   [m m-1] default = 0.0
+                                ! The constant of proportionality between self-attraction and loading (SAL)
+                                ! geopotential anomaly and barotropic geopotential anomaly. This is only used if
+                                ! SAL_SCALAR_APPROX is true or USE_PREVIOUS_TIDES is true.
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False

--- a/exps/NWA12.COBALT/INPUT/MOM_input
+++ b/exps/NWA12.COBALT/INPUT/MOM_input
@@ -412,10 +412,7 @@ TIDE_MF = True                  !   [Boolean] default = False
 TIDE_MM = True                  !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing at the MM frequency. This is only used
                                 ! if TIDES is true.
-TIDE_SAL_SCALAR_VALUE = 0.01    !   [m m-1]
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
+SAL_SCALAR_VALUE = 0.01         !   [m m-1]
 TIDE_USE_EQ_PHASE = True        !   [Boolean] default = False
                                 ! Correct phases by calculating equilibrium phase arguments for TIDE_REF_DATE.
 

--- a/exps/NWA12.COBALT/MOM_parameter_doc.all
+++ b/exps/NWA12.COBALT/MOM_parameter_doc.all
@@ -1109,10 +1109,10 @@ SAL_USE_BPA = False             !   [Boolean] default = False
 SAL_SCALAR_APPROX = True        !   [Boolean] default = True
                                 ! If true, use the scalar approximation to calculate self-attraction and
                                 ! loading.
-SAL_SCALAR_VALUE = 0.01         !   [m m-1] default = 0.01
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if USE_SAL_SCALAR is true or USE_PREVIOUS_TIDES is true.
+SAL_SCALAR_VALUE = 0.01         !   [m m-1] default = 0.0
+                                ! The constant of proportionality between self-attraction and loading (SAL)
+                                ! geopotential anomaly and barotropic geopotential anomaly. This is only used if
+                                ! SAL_SCALAR_APPROX is true or USE_PREVIOUS_TIDES is true.
 SAL_HARMONICS = False           !   [Boolean] default = False
                                 ! If true, use the online spherical harmonics method to calculate
                                 ! self-attraction and loading.

--- a/exps/NWA12.COBALT/MOM_parameter_doc.short
+++ b/exps/NWA12.COBALT/MOM_parameter_doc.short
@@ -333,6 +333,10 @@ CORIOLIS_EN_DIS = True          !   [Boolean] default = False
                                 ! used.
 
 ! === module MOM_self_attr_load ===
+SAL_SCALAR_VALUE = 0.01         !   [m m-1] default = 0.0
+                                ! The constant of proportionality between self-attraction and loading (SAL)
+                                ! geopotential anomaly and barotropic geopotential anomaly. This is only used if
+                                ! SAL_SCALAR_APPROX is true or USE_PREVIOUS_TIDES is true.
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False

--- a/exps/NWA12.tidesonly/MOM_parameter_doc.all
+++ b/exps/NWA12.tidesonly/MOM_parameter_doc.all
@@ -1011,9 +1011,9 @@ SAL_SCALAR_APPROX = True        !   [Boolean] default = True
                                 ! If true, use the scalar approximation to calculate self-attraction and
                                 ! loading.
 SAL_SCALAR_VALUE = 0.094        !   [m m-1] default = 0.0
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if USE_SAL_SCALAR is true or USE_PREVIOUS_TIDES is true.
+                                ! The constant of proportionality between self-attraction and loading (SAL)
+                                ! geopotential anomaly and barotropic geopotential anomaly. This is only used if
+                                ! SAL_SCALAR_APPROX is true or USE_PREVIOUS_TIDES is true.
 SAL_HARMONICS = False           !   [Boolean] default = False
                                 ! If true, use the online spherical harmonics method to calculate
                                 ! self-attraction and loading.

--- a/exps/NWA12.tidesonly/MOM_parameter_doc.short
+++ b/exps/NWA12.tidesonly/MOM_parameter_doc.short
@@ -201,9 +201,9 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_self_attr_load ===
 SAL_SCALAR_VALUE = 0.094        !   [m m-1] default = 0.0
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if USE_SAL_SCALAR is true or USE_PREVIOUS_TIDES is true.
+                                ! The constant of proportionality between self-attraction and loading (SAL)
+                                ! geopotential anomaly and barotropic geopotential anomaly. This is only used if
+                                ! SAL_SCALAR_APPROX is true or USE_PREVIOUS_TIDES is true.
 
 ! === module MOM_tidal_forcing ===
 TIDE_M2 = True                  !   [Boolean] default = False

--- a/xmls/NEP10/MOM_inputs/2024_08/MOM_input
+++ b/xmls/NEP10/MOM_inputs/2024_08/MOM_input
@@ -913,10 +913,7 @@ TIDE_P1 = True
 TIDE_Q1 = True
 TIDE_MM = True
 TIDE_MF = True
-TIDE_SAL_SCALAR_VALUE = 0.010   !   [m m-1]
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
+SAL_SCALAR_VALUE = 0.010        !   [m m-1]
 TIDE_USE_EQ_PHASE = True
 
 ! === module ocean_model_init ===

--- a/xmls/NWA12/MOM_inputs/2024_03/MOM_input
+++ b/xmls/NWA12/MOM_inputs/2024_03/MOM_input
@@ -412,10 +412,7 @@ TIDE_MF = True                  !   [Boolean] default = False
 TIDE_MM = True                  !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing at the MM frequency. This is only used
                                 ! if TIDES is true.
-TIDE_SAL_SCALAR_VALUE = 0.01    !   [m m-1]
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
+SAL_SCALAR_VALUE = 0.01         !   [m m-1]
 TIDE_USE_EQ_PHASE = True        !   [Boolean] default = False
                                 ! Correct phases by calculating equilibrium phase arguments for TIDE_REF_DATE.
 


### PR DESCRIPTION
[MOM6 PR819](https://github.com/NOAA-GFDL/MOM6/pull/819 ) also deprecates TIDE_SAL_SCALAR_VALUE in favor of SAL_SCALAR_VALUE. This PR reflects that change.