### PR TITLE
More intelligently search for the right post-processed files

### DIFF
--- a/diagnostics/physics/plot_common.py
+++ b/diagnostics/physics/plot_common.py
@@ -193,14 +193,15 @@ def open_var(pp_root, kind, var, hsmget=HSMGet()):
     if isinstance(pp_root, str):
         pp_root = Path(pp_root)
     freq = 'daily' if 'daily' in kind else 'monthly'
-    if not (pp_root / 'pp' / kind / 'ts' / freq).is_dir():
-        raise FileNotFoundError(errno.ENOENT, 'Could not find post-processed directory', str(pp_root / 'pp' / kind / 'ts' / freq))
+    pp_dir = pp_root / 'pp' / kind / 'ts' / freq
+    if not pp_dir.is_dir():
+        raise FileNotFoundError(errno.ENOENT, 'Could not find post-processed directory', str(pp_dir))
     # Get all of the available post-processing chunk directories (assuming chunks in units of years)
-    available_chunks = list((pp_root / 'pp' / kind / 'ts' / freq).glob('*yr'))
+    available_chunks = list(pp_dir.glob('*yr'))
     if len(available_chunks) == 0:
         raise FileNotFoundError(errno.ENOENT, 'Could not find post-processed chunk subdirectory')
     # Sort from longest to shortest chunk
-    sorted_chunks = list(sorted(available_chunks, key=lambda x: int(x.name[0:-2]), reverse=True))
+    sorted_chunks = sorted(available_chunks, key=lambda x: int(x.name[0:-2]), reverse=True)
     for chunk in sorted_chunks:
         # Look through the available chunks and return for the 
         # largest chunk that has file(s). 


### PR DESCRIPTION
To support newer simulations, this changes the behavior of `open_var` to look for the right post-processed files, without any hard coding of the dates or chunk lengths. 

The general assumptions are
1. A path following the standard frepp naming, for example `{pp_root}/pp/ocean_monthly/ts/monthly/`, exists (error if not)
2. Within that path, one or more directories with names like `*yr` exist (error if not)
3. Of the directories above, whichever has the largest number in the name and contains one or more post-processed files of the right variable is the one to use. 

We generally post-process two different chunk sizes, one of 5 years and the other the length of the simulation. This should work for that. One way to get a suboptimal result would be if the simulation length was longer than the longest chunk; for example, a 25 year simulation with 5 year and 20 year chunks. This is an unlikely user error though. 