### PR TITLE
updating README to indicate NEP-specific file for WOA climatological sst

### DIFF
--- a/tools/rivers/bgc/NEP/README.md
+++ b/tools/rivers/bgc/NEP/README.md
@@ -68,7 +68,10 @@ matlab232 -nodisplay -nosplash -nodesktop -r "run('ArcticGro_Process.m');exit;"
 estimates based on available observation, while using GlobalNEWS to fill in
 some gaps. 
 ```
-cp /archive/ynt/woa_nep5k_sst_climo.nc ./Data/
+# copying over NEP-regridded, WOA23 SST climatology.
+# This file was generated using WOA23 decadal mean sst at 1/4 degree resolution
+
+cp /archive/ynt/woa_nep10k_sst_climo.nc ./Data/
 matlab232 -nodisplay -nosplash -nodesktop -r "run('mapriv_combined_NEP10k.m');exit;"
 ```
 As was the case for globalNEWS2, I recommend running these with "inspect_map = 'y'" until

--- a/tools/rivers/bgc/NEP/README.md
+++ b/tools/rivers/bgc/NEP/README.md
@@ -68,7 +68,7 @@ matlab232 -nodisplay -nosplash -nodesktop -r "run('ArcticGro_Process.m');exit;"
 estimates based on available observation, while using GlobalNEWS to fill in
 some gaps. 
 ```
-cp /archive/ynt//woa_sst_climo.nc ./Data/
+cp /archive/ynt/woa_nep5k_sst_climo.nc ./Data/
 matlab232 -nodisplay -nosplash -nodesktop -r "run('mapriv_combined_NEP10k.m');exit;"
 ```
 As was the case for globalNEWS2, I recommend running these with "inspect_map = 'y'" until

--- a/tools/rivers/bgc/NEP/mapriv_combined_NEP10k.m
+++ b/tools/rivers/bgc/NEP/mapriv_combined_NEP10k.m
@@ -2,7 +2,7 @@
 % grid. Run on matlab97 or above.
 
 clear all;
-addpath /home/cas/matlab
+addpath /home/cas/matlab_budget_codes
 nc64startup
 
 % name of netcdf file to be created
@@ -12,7 +12,7 @@ nc_file_name = 'RiverNutrients_Combined_Q100_NEP10k.nc';
 NEWS_file = 'RiverNutrients_GlobalNEWS2_plusFe_Q100_NEP10k.nc';
 
 % load in monthly world ocean T, S climatology for saturated oxygen calculation
-temp = ncread('Data/woa_sst_climo.nc','t_an');
+temp = ncread('Data/woa_nep10k_sst_climo.nc','t_an');
 woa_temp = permute(temp,[3 2 1]);
 
 % Parameters for the assignment algorithm.


### PR DESCRIPTION
The SST values used for calculating oxygen saturation are from a domain-specific climatology from World Ocean Atlas. The current file is for the NWA. We need to update this with sst values regridded to the NEP domain. 