### PR TITLE
Modify longitude handling in subset template to handle domains that cross the dateline

### DIFF
--- a/tools/boundary/glorys_obc_workflow/mom6_obc_workflow.sh
+++ b/tools/boundary/glorys_obc_workflow/mom6_obc_workflow.sh
@@ -90,7 +90,7 @@ log_message "Generating config.yaml..."
 cat <<EOF > config.yaml
 _WALLTIME: "1440"
 _NPROC: "1"
-_EMAIL_NOTIFACTION: "fail"
+_EMAIL_NOTIFICATION: "fail"
 _USER_EMAIL: "$USER@noaa.gov"
 _LOG_PATH: "./log/$CURRENT_DATE/%x.o%j"
 _UDA_GLORYS_DIR: "/uda/Global_Ocean_Physics_Reanalysis/global/daily"
@@ -157,7 +157,7 @@ if ! $DO_NCRCAT; then
     	    subset_args="$subset_args --convert_lon"
 	fi
         subset_job_id=$(sbatch --job-name="glorys_subset_${year}_${month}_${day}" \
-                              scripts/subset_glorys.sh $year $month $day | awk '{print $4}')
+                              scripts/subset_glorys.sh $subset_arags | awk '{print $4}')
 
         log_message "Submitting fill_nan job for $current_date..."
         fill_job_id=$(sbatch --dependency=afterok:$subset_job_id \

--- a/tools/boundary/glorys_obc_workflow/template/fill_glorys_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/fill_glorys_template.sh
@@ -2,7 +2,7 @@
 #SBATCH --partition=batch
 #SBATCH --time={{ _WALLTIME }}
 #SBATCH --ntasks={{ _NPROC }}
-#SBATCH --mail-type={{ _EMAIL_NOTIFACTION }}
+#SBATCH --mail-type={{ _EMAIL_NOTIFICATION }}
 #SBATCH --mail-user={{ _USER_EMAIL }}
 #SBATCH --output={{ _LOG_PATH }}
 #SBATCH --error={{ _LOG_PATH }}

--- a/tools/boundary/glorys_obc_workflow/template/ncrcat_obc_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/ncrcat_obc_template.sh
@@ -2,7 +2,7 @@
 #SBATCH --partition=batch
 #SBATCH --time={{ _WALLTIME  }}
 #SBATCH --ntasks={{ _NPROC }}
-#SBATCH --mail-type={{ _EMAIL_NOTIFACTION }}
+#SBATCH --mail-type={{ _EMAIL_NOTIFICATION }}
 #SBATCH --mail-user={{ _USER_EMAIL }}
 #SBATCH --output={{ _LOG_PATH }}
 #SBATCH --error={{ _LOG_PATH }}

--- a/tools/boundary/glorys_obc_workflow/template/submit_python_make_obc_day_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/submit_python_make_obc_day_template.sh
@@ -2,7 +2,7 @@
 #SBATCH --partition=batch
 #SBATCH --time={{ _WALLTIME }}
 #SBATCH --ntasks={{ _NPROC }}
-#SBATCH --mail-type={{ _EMAIL_NOTIFACTION }}
+#SBATCH --mail-type={{ _EMAIL_NOTIFICATION }}
 #SBATCH --mail-user={{ _USER_EMAIL }}
 #SBATCH --output={{ _LOG_PATH }}
 #SBATCH --error={{ _LOG_PATH }}

--- a/tools/boundary/glorys_obc_workflow/template/subset_glorys_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/subset_glorys_template.sh
@@ -2,7 +2,7 @@
 #SBATCH --partition=batch
 #SBATCH --time={{ _WALLTIME }}
 #SBATCH --ntasks={{ _NPROC }}
-#SBATCH --mail-type={{ _EMAIL_NOTIFACTION }}
+#SBATCH --mail-type={{ _EMAIL_NOTIFICATION }}
 #SBATCH --mail-user={{ _USER_EMAIL }}
 #SBATCH --output={{ _LOG_PATH }}
 #SBATCH --error={{ _LOG_PATH }}
@@ -11,7 +11,7 @@
 
 # Load required modules
 module load cdo
-module load nco/5.0.1
+module load nco
 module load gcp
 
 # Input arguments
@@ -76,9 +76,11 @@ process_variable() {
         if [[ -f $filename ]]; then
             echo "Processing file: $filename"
             local subset_file="$var_dir/${var}_subset.nc"
-
+            local tmp_file="$var_dir/${var}_tmp.nc"
+            cdo sellonlatbox,0,360,-90,90 $filename $tmp_file
+            
             # Subset and adjust the file
-            if ! ncks -d longitude,${LON_MIN},${LON_MAX} -d latitude,${LAT_MIN},${LAT_MAX} --mk_rec_dmn time "$filename" "$subset_file"; then
+            if ! ncks -d longitude,${LON_MIN},${LON_MAX} -d latitude,${LAT_MIN},${LAT_MAX} --mk_rec_dmn time "$tmp_file" "$subset_file"; then
                 echo "Error: ncks failed for $filename"
                 exit 1
             fi


### PR DESCRIPTION
When a domain crosses the dateline (in my case the Pacific Islands regional model), generating the glorys bgc with the current workflow might not be as straight forward. Therefore, converting the longitude coordinates from a -180 to 180 system to a 0 to 360 grid while maintaining the full global coverage, makes it easier to select the desired domain without interruption. 