### PR TITLE
Adding NEP-specific river runnoff codes.

### DIFF
--- a/tools/rivers/bgc/NEP/make_discharge_climatology_nep.m
+++ b/tools/rivers/bgc/NEP/make_discharge_climatology_nep.m
@@ -1,14 +1,15 @@
 clear all;
-addpath /home/cas/matlab
+addpath /home/cas/matlab_budget_codes/
 nc64startup;
 
 syear = 1993;
-eyear = 2019;
+eyear = 2022;
 num_years = eyear-syear+1;
-readme = '1993-2019 monthly NEP10k climatology from GLOFAS/Hill (May 12, 2023 from Liz Drenkard), kg m-2 sec-1';
+readme = '1993-2022 monthly NEP10k climatology from GLOFAS/Hill (March 7, 2025 from Liz Drenkard), kg m-2 sec-1';
 
 % get grid information
-file_name = ['/archive/cas/Regional_MOM6/NEP10k/glofas_hill_05122023/glofas_hill_dis_runoff_mac_',num2str(syear,'%4u'),'.nc']
+%file_name = ['/archive/cas/Regional_MOM6/NEP10k/glofas_hill_05122023/glofas_hill_dis_runoff_mac_',num2str(syear,'%4u'),'.nc']
+file_name = ['/archive/e1n/mom6/NEP/runoff/glofas/nep_10km/glofas_v4_hill_dis_runoff_',num2str(syear,'%4u'),'.nc']
 lon = ncread(file_name,'lon');
 lat = ncread(file_name,'lat');
 nlat = size(lat,2);
@@ -19,8 +20,9 @@ area = ncread(file_name,'area');
 runoff_mc = zeros(nlon,nlat,12);
 
 for yr = syear:eyear
-  file_name = ['/archive/cas/Regional_MOM6/NEP10k/glofas_hill_05122023/glofas_hill_dis_runoff_mac_',num2str(yr,'%4u'),'.nc']
-    
+  %file_name = ['/archive/cas/Regional_MOM6/NEP10k/glofas_hill_05122023/glofas_hill_dis_runoff_mac_',num2str(yr,'%4u'),'.nc']
+  file_name = ['/archive/e1n/mom6/NEP/runoff/glofas/nep_10km/glofas_v4_hill_dis_runoff_',num2str(yr,'%4u'),'.nc']
+  
   time = ncread(file_name,'time');
   ntime = size(time,1);
   
@@ -58,4 +60,4 @@ for m = 1:12;
     pause
 end
 
-save glofas_hill_runoff_monthlyclim_NEP10k_05122023 runoff area lat lon readme;
+save glofas_hill_runoff_monthlyclim_NEP10k_04072025 runoff area lat lon readme;

--- a/tools/rivers/bgc/NEP/mapriv_NEWS2.m
+++ b/tools/rivers/bgc/NEP/mapriv_NEWS2.m
@@ -1,8 +1,9 @@
+
 % Routine to map Global NEWS nutrient data onto the MOM6 Arctic grid @ 
 
 clear all;
-addpath /home/cas/matlab
-nc64startup;
+addpath /home/cas/matlab_budget_codes
+nc64startup
 
 % name of netcdf file to be created
 nc_file_name = 'RiverNutrients_GlobalNEWS2_plusFe_Q100_NEP10k.nc';
@@ -89,7 +90,7 @@ Qnat_all = hydrology.Qnat*1e9/(86400*365);
 % found in the same directory as the data file                            %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % NEP
-load glofas_hill_runoff_monthlyclim_NEP10k_05122023.mat;
+load glofas_hill_runoff_monthlyclim_NEP10k_04072025.mat;
 % Arctic
 %load glofas_hill_runoff_monthlyclim_arctic12k_05112023.mat;
 lon_mod = lon;
@@ -294,23 +295,6 @@ for k=1:num_rivers
         n = n+1;
         Q_sum2 = Q_sum1 + Q_mod_vec(dist_sort_ind(n));
       end
-      % I generally find that the search algorithm works best when you keep
-      % grabbing points until the total flow captured exceeds the flow in
-      % the river.  If you uncomment the the first part of the "if"
-      % statement here will pick the last below if it is closer than the
-      % first above.  However, I've found that this option sometimes fails
-      % to map important rivers.
-      %if abs(Q_sum1 - Qact_sort(k)) < abs(Q_sum2 - Qact_sort(k))
-      %  nrp = n-1;  % number of runoff points
-      %  [Q_sum1 Qact_sort(k)]  % a quick check for comparable flow
-      %  din_conc_vec(dist_sort_ind(1:nrp)) = DIN_conc_sort(k);
-      %  don_conc_vec(dist_sort_ind(1:nrp)) = DON_conc_sort(k);
-      %  dip_conc_vec(dist_sort_ind(1:nrp)) = DIP_conc_sort(k);
-      %  dop_conc_vec(dist_sort_ind(1:nrp)) = DOP_conc_sort(k);
-      %  pn_conc_vec(dist_sort_ind(1:nrp)) = PN_conc_sort(k);
-      %  pp_conc_vec(dist_sort_ind(1:nrp)) = PP_conc_sort(k);
-      %  si_conc_vec(dist_sort_ind(1:nrp)) = Si_conc_sort(k);
-      %else
         nrp = n; % number of runoff points
         [Q_sum2 Qact_sort(k)] % a quick check for comparable flow
         din_conc_vec(dist_sort_ind(1:nrp)) = DIN_conc_sort(k);
@@ -320,7 +304,6 @@ for k=1:num_rivers
         pn_conc_vec(dist_sort_ind(1:nrp)) = PN_conc_sort(k);
         pp_conc_vec(dist_sort_ind(1:nrp)) = PP_conc_sort(k);
         si_conc_vec(dist_sort_ind(1:nrp)) = Si_conc_sort(k);
-      %end
         
       if inspect_map == 'y'
         figure(1)
@@ -341,8 +324,7 @@ for k=1:num_rivers
         colorbar;
 
         % provide a few diagnostics to ensure the calculation was done
-        % correctly (remove semicolon to inspect as they are mapped in
-        % the matlab output line.  Feel free to add more here.
+        % correctly (remove semicolon to inspect as they are mapped)
         N_conc = DIN_conc_sort(k) + DON_conc_sort(k) + PN_conc_sort(k);
         P_conc = DIP_conc_sort(k) + DOP_conc_sort(k) + PP_conc_sort(k);
         Si_conc = Si_conc_sort(k);

--- a/tools/rivers/bgc/NEP/submit_batch_runoff
+++ b/tools/rivers/bgc/NEP/submit_batch_runoff
@@ -1,0 +1,8 @@
+#!/bin/bash
+runoff_dir=/work/Liz.Drenkard/mom6/nep_10km/setup/runoff
+for yr in {1993..2024}; do
+    echo $yr
+    sbatch -p analysis submit_python_runoff_script $runoff_dir/write_runoff_glofas_hill_dis_batch_v4.py $yr $runoff_dir/batch_submit/
+done
+
+

--- a/tools/rivers/bgc/NEP/submit_python_runoff_script
+++ b/tools/rivers/bgc/NEP/submit_python_runoff_script
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH --job-name=runoff_nep10k
+#SBATCH --constraint=bigmem
+#SBATCH --partition=analysis
+#SBATCH --time=01:40:00
+#SBATCH --ntasks=1
+
+# Usage: sbatch submit_python_runoff_script <PYTHON_SCRIPT> <YEAR> <OUTPUT_DIR>
+# This script is used to submit river runoff remapping (GloFAS and Hill et al. to NEP10k) scripts on GFDL PPAN
+source $MODULESHOME/init/sh
+module load miniforge
+conda activate /net3/e1n/miniconda3/envs/mom6 
+
+cd $TMPDIR
+
+python_script=$1
+year=$2
+outdir=$3
+
+echo $year
+python $python_script $year $outdir
+
+

--- a/tools/rivers/bgc/NEP/write_runoff_glofas_hill_dis_batch_v4.py
+++ b/tools/rivers/bgc/NEP/write_runoff_glofas_hill_dis_batch_v4.py
@@ -1,0 +1,318 @@
+import numpy as np
+import pandas as pd 
+import xesmf
+import xarray
+import sys
+import copy
+import warnings
+warnings.filterwarnings("ignore")
+
+def update_stencil_sum(ocean_mask):
+    
+    # Make 3x3 stensil 
+    sten_nlat = 3
+    sten_nlon = 3
+
+    glofas_stensil_sum = np.zeros(ocean_mask.shape)
+    for nlat in range(sten_nlat):
+        ilat_last = -(2-nlat)
+        if ilat_last == 0:
+            ilat_last = None
+        
+        for nlon in range(sten_nlon):
+            ilon_last = -(2-nlon)
+            if ilon_last == 0:
+                ilon_last = None
+       
+            glofas_stensil_sum[1:-1,1:-1] += ocean_mask[nlat:ilat_last,nlon:ilon_last]
+        
+    return glofas_stensil_sum 
+
+def get_glofas_pour_points():
+    ldd_modified = copy.deepcopy(ldd)
+    # GloFAS VERSION 3: editing pour points along map seam in Russia at date line. 
+    # Not sure if these are the best points to change or what happens with this runoff
+    #ldd_modified[168,299:301]=1
+    #ldd_modified[132,299]=1
+   
+    # GloFAS VERSION 4: editing pour points along map seam in Russia Chukotka Region at date line.
+    lat_idx = np.where(np.round(glofas_lat,3) == 68.875)[0][0]
+    lon_idx = np.where(np.round(glofas_lon,3) == 180.025)[0][0]
+    ldd_modified[lat_idx,lon_idx]=1 # change from 5 to stop advancing halo point
+    
+    # GloFAS VERSION 4: editing pour points to connect Columbia River to the ocean
+    lat_idx = np.where(np.round(glofas_lat,3) == 46.175)[0][0]
+    lon_idx = np.where(np.round(glofas_lon,3) == 236.275)[0][0]
+    ldd_modified[lat_idx,lon_idx]=5 # change to 5 to advance halo point    
+    lat_idx = np.where(np.round(glofas_lat,3) == 46.225)[0][0]
+    lon_idx = np.where(np.round(glofas_lon,3) == 236.475)[0][0]
+    ldd_modified[lat_idx,lon_idx]=5 # change to 5 to advance halo point   
+    
+    glofas_ocean_mask = np.isnan(ldd)
+
+    # initialize the while loop
+    n_updates = 1
+
+    # continue 
+    while n_updates>0:
+        n_updates = 0
+        ocean_stencil_sum = update_stencil_sum(glofas_ocean_mask)    
+        for jj in range(len(glofas_lat)):
+            for ii in range(len(glofas_lon)):
+            
+                if (ldd_modified[jj,ii]==5) and (glofas_ocean_mask[jj,ii]==0) and (ocean_stencil_sum[jj,ii]>0):
+                    # update ocean mask so counted in next calculation of the stencil sum
+                    glofas_ocean_mask[jj,ii] = 1
+                    n_updates+=1
+                
+    pour_points = (ldd_modified==5)*(ocean_stencil_sum>0)
+    
+    return pour_points
+
+def get_mom_mask_for_glofas():
+    # eliminate pour points outside of nep domain so they won't be mapped on the boundary in the d2s phase
+    mom_to_glofas = xesmf.Regridder(
+        {'lat': lat, 'lon': lon, 'lat_b': latb, 'lon_b': lonb},
+        {'lon': glofas_lon, 'lat': glofas_lat, 'lon_b': glofas_lonb , 'lat_b': glofas_latb },
+        method='conservative',
+        periodic=True,
+        reuse_weights=False)
+    mom_mask_for_glofas = mom_to_glofas(np.ones((ocn_mask.shape)))
+    
+    mom_mask_for_glofas[mom_mask_for_glofas<.5]=0
+    mom_mask_for_glofas[mom_mask_for_glofas>.5]=1
+    
+    return mom_mask_for_glofas.astype(bool)
+
+
+def write_runoff(glofas, hgrid, coast_mask, out_file):
+    # From Alistair
+    area = (hgrid.area[::2, ::2] + hgrid.area[1::2, 1::2]) + (hgrid.area[1::2, ::2] + hgrid.area[::2, 1::2])
+
+    pour_points = get_glofas_pour_points()
+    glofas_mom_pour_points = pour_points*get_mom_mask_for_glofas()
+
+    # Identify nearest coastal land point to GloFAS pour points
+    # Source pour points indices
+    flat_pour_point_mask = glofas_mom_pour_points.ravel().astype('bool')
+    pour_lon = glo_lons.ravel()[flat_pour_point_mask]
+    pour_lat = glo_lats.ravel()[flat_pour_point_mask]
+    #linear index of glofas_elements
+    glo_id = np.arange(np.prod(glofas_mom_pour_points.shape))
+    pour_id = glo_id[flat_pour_point_mask]
+
+    # Coastal destination indices
+    # Flatten mask and coordinates to 1D
+    flat_coast_mask = coast_mask.ravel().astype('bool')
+    coast_lon = lon.ravel()[flat_coast_mask]
+    coast_lat = lat.ravel()[flat_coast_mask]
+    #linear index of mom elements
+    mom_id = np.arange(np.prod(coast_mask.shape))
+    coast_id = mom_id[flat_coast_mask]
+    # Use xesmf to find the index of the nearest coastal cell
+    # for every grid cell in the MOM domain
+    glo_coast_to_mom = xesmf.Regridder(
+       {'lat': coast_lat, 'lon': coast_lon},
+       {'lat': pour_lat, 'lon': pour_lon},
+       method='nearest_s2d',
+       locstream_in=True,
+       locstream_out=True,
+       reuse_weights=False)
+
+    nearest_glo_coast = glo_coast_to_mom(coast_id).ravel()
+    
+    tmp_glo_values = glofas.values
+
+    # discharge on GloFAS grid, reshaped to 2D (time, grid_id)
+    raw = tmp_glo_values.reshape([glofas.shape[0],-1])
+
+    # Zero array that will be filled with runoff at coastal cells
+    mom_glo_filled = np.zeros((raw.shape[0],np.prod(ocn_mask.shape)))
+
+    # Loop over each GloFAS pour point and add it to the nearest coastal cell
+    for mom_i, glo_i in zip(nearest_glo_coast,pour_id):
+        mom_glo_filled[:, mom_i] += raw[:, glo_i] 
+
+    # Hill et al product only extends to mid 2021 so only including through 2020
+    if yr < 2021:
+       hill_coast_to_mom = xesmf.Regridder({'lat': coast_lat, 'lon': coast_lon},
+                                 {'lat': hill_lat, 'lon': hill_lon},
+                                 method='nearest_s2d',
+                                 locstream_in=True,
+                                 locstream_out=True,
+                                 reuse_weights=False) 
+       nearest_hill_coast = hill_coast_to_mom(coast_id).ravel()
+       # Loop over each GloFAS pour point and add it to the nearest coastal cell
+       mom_hill_filled = np.zeros(([raw.shape[0],np.prod(ocn_mask.shape)]))
+       for mom_i, hill_i in zip(nearest_hill_coast, range(len(nearest_hill_coast))):
+           mom_hill_filled[:, mom_i] += hdis.values[:, hill_i]/(24*60*60) # m3 d-1 -> m3 s-1
+
+       # replace glofas_filled indicies with hill values
+       mom_glo_filled[:,np.unique(nearest_hill_coast)] = mom_hill_filled[:,np.unique(nearest_hill_coast)]
+
+    # Reshape back to 3D and convert to kg m-2 s-1: multiply by 1000 kg m-3 and divide by grid cell area in m2
+    filled_reshape = 1000*mom_glo_filled.reshape((glofas.shape[0],ocn_mask.shape[0],ocn_mask.shape[1]))/area.values
+
+    # Convert to xarray
+    ds = xarray.Dataset({
+        'runoff': (['time', 'y', 'x'], filled_reshape),
+        'area': (['y', 'x'], area.data),
+        'lat': (['y', 'x'], lat.data),
+        'lon': (['y', 'x'], lon.data)
+        },
+        coords={'time': glofas['time'].data, 'y': np.arange(filled_reshape.shape[1]), 'x': np.arange(filled_reshape.shape[2])}
+    )
+
+    # Drop '_FillValue' from all variables when writing out
+    all_vars = list(ds.data_vars.keys()) + list(ds.coords.keys())
+    encodings = {v: {'_FillValue': None} for v in all_vars}
+
+    # Make sure time has the right units and datatype
+    # otherwise it will become an int and MOM will fail. 
+    encodings['time'].update({
+        'units': 'days since 1950-01-01',
+        'dtype': float, 
+        'calendar': 'gregorian'
+    })
+
+    ds['time'].attrs = {'cartesian_axis': 'T'}
+    ds['x'].attrs = {'cartesian_axis': 'X'}
+    ds['y'].attrs = {'cartesian_axis': 'Y'}
+    ds['lat'].attrs = {'units': 'degrees_north'}
+    ds['lon'].attrs = {'units': 'degrees_east'}
+    ds['runoff'].attrs = {'units': 'kg m-2 s-1'}
+
+    # Write out
+    ds.to_netcdf(
+        out_file,
+        unlimited_dims=['time'],
+        format='NETCDF3_64BIT',
+        encoding=encodings,
+        engine='netcdf4'
+    )
+    ds.close()
+
+
+if __name__ == '__main__':
+    # Determine coastal points in NEP domain
+    ocn_mask = xarray.open_dataset('/work/Liz.Drenkard/mom6/NEP_ocean_static_nomask.nc').wet.values.astype(bool)
+    
+    stencil_sum = 0 * ocn_mask
+    
+    # sum ocean mask values to the:     north          south                 east                   west
+    stencil_sum[1:-1,1:-1] = ~ocn_mask[2:,1:-1] + ~ocn_mask[:-2,1:-1] + ~ocn_mask[1:-1,:-2] + ~ocn_mask[1:-1,2:]
+    ## Domain Edges
+    ### North     
+    stencil_sum[-1,1:-1]   =                      ~ocn_mask[-2,1:-1]  + ~ocn_mask[-1,:-2]   + ~ocn_mask[-1,2:]
+    ### South
+    stencil_sum[0,1:-1]    = ~ocn_mask[1,1:-1]  +                       ~ocn_mask[0,:-2]    + ~ocn_mask[0,2:]
+    ### East                          
+    stencil_sum[1:-1,-1]   = ~ocn_mask[2:,-1]   + ~ocn_mask[:-2,-1]   +                       ~ocn_mask[1:-1,-2]    
+    ### West                          
+    stencil_sum[1:-1,0]    = ~ocn_mask[2:,0]    + ~ocn_mask[:-2,0]    + ~ocn_mask[1:-1,1]
+
+    ## Domain Corners
+    ## Northwest
+    stencil_sum[-1,0]      =                      ~ocn_mask[-2,0]     + ~ocn_mask[-1,2]
+    ## Northeast               
+    stencil_sum[-1,-1]     =                      ~ocn_mask[-2,-1]    +                       ~ocn_mask[-1,-2]
+    ## Southeast               
+    stencil_sum[0,-1]      = ~ocn_mask[1,-1]    +                                             ~ocn_mask[0,-2]
+    ## Southwest
+    stencil_sum[0,0]       = ~ocn_mask[1,0]     +                       ~ocn_mask[0,1]
+    
+    coast = (ocn_mask)*(stencil_sum)
+
+    # Load regional ocean hgrid
+    hgrid = xarray.open_dataset( '/work/Liz.Drenkard/mom6/nep_10km/setup/grid/ocean_hgrid.nc')
+    lon = hgrid.x[1::2, 1::2].values
+    lonb = hgrid.x[::2, ::2].values
+    lat = hgrid.y[1::2, 1::2].values
+    latb = hgrid.y[::2, ::2].values 
+     
+    # Load GloFAS local drain direction map
+    ldd = xarray.open_dataset('/work/Liz.Drenkard/mom6/nep_10km/setup/runoff/ncks_glofas/ldd_v4.0_NEP_subset.nc').ldd.values
+    
+    # GloFAS Version 3.1: Mackenzie river patch
+    #ldd[132,743:746]=5
+
+    yr=int(sys.argv[1])
+    # GloFAS 4.0 subset to model region:
+    glo_files = [f'/work/Liz.Drenkard/mom6/nep_10km/setup/runoff/ncks_glofas/glofas_v4.0_nep_subset_{y}.nc' for y in [yr-1, yr, yr+1]]
+
+
+    glofas = (
+         xarray.open_mfdataset(glo_files, combine='by_coords')
+         .rename({'latitude': 'lat', 'longitude': 'lon'})
+	 .sel(time=slice(f'{yr-1}-12-31 12:00:00', f'{yr+1}-01-01 12:00:00'))
+         .dis24)
+     
+    glofas_lat = glofas['lat'].values 
+    glofas_lon = glofas['lon'].values
+    glofas_lon[glofas_lon<0]=glofas_lon[glofas_lon<0]+360
+    deg_incr = abs(np.unique(np.diff(glofas_lat))[0]) 
+    # updated icrement for  version 4.0 of GloFAS, assumes constant diff for both lats & lons : 
+    glofas_latb = np.arange(glofas_lat[0] + deg_incr/2., glofas_lat[-1]-deg_incr, -deg_incr)
+    glofas_lonb = np.arange(glofas_lon[0] - deg_incr/2., glofas_lon[-1]+deg_incr, deg_incr) 
+    glo_lons,glo_lats = np.meshgrid(glofas_lon,glofas_lat) 
+    
+    #print(glofas_lonb.shape,glofas_lon.shape,glofas_latb.shape,glofas_lat.shape) 
+    
+    # UNCOMMENT FOR HILL DATA
+    if yr < 2021: 
+        hill_files = [f'/work/Liz.Drenkard/external_data/goa_freshwater_discharge/goa_dischargex_0901{y}_0831{y+1}.nc' for y in [yr-1, yr]]
+        hill = xarray.open_mfdataset(hill_files,combine='nested',concat_dim='time')
+        hill['time'] = pd.to_datetime([(str(hill.year.values[nt])+'-'+str(hill.month.values[nt]).zfill(2)+'-'+str(hill.day.values[nt]).zfill(2)) for nt in range(len(hill.day))])
+
+    # using climatological hill data with 2021 half year
+    elif yr == 2021:
+        hill_files = ['/work/Liz.Drenkard/external_data/goa_freshwater_discharge/goa_dischargex_09012020_08312021.nc',
+                     '/work/Liz.Drenkard/external_data/goa_freshwater_discharge/goa_dischargex_09011991_08312021_clim.nc']
+        hill = xarray.open_mfdataset(hill_files,combine='nested',concat_dim='time')
+        years = hill.year.values
+        years[years==1992] = 2021
+        years[years==1993] = 2022
+        hill['time'] = pd.to_datetime([(str(years[nt])+'-'+str(hill.month.values[nt]).zfill(2)+'-'+str(hill.day.values[nt]).zfill(2)) for nt in range(len(hill.day))])
+
+    # using only hill climatological data
+    else:
+        hill_files = ['/work/Liz.Drenkard/external_data/goa_freshwater_discharge/goa_dischargex_09011991_08312021_clim.nc',
+                     '/work/Liz.Drenkard/external_data/goa_freshwater_discharge/goa_dischargex_09011991_08312021_clim.nc']
+        hill = xarray.open_mfdataset(hill_files,combine='nested',concat_dim='time')
+        years = hill.year.values
+        months = hill.month.values
+        days = hill.day.values
+
+        # updating the years and days for respective years
+        middle_year_start = np.argmax(years)
+        years[:middle_year_start] = yr-1
+        middle_year_seam_start = np.argmin(years) + int(yr%4==0) # leap year condition on the end 
+
+        # leap year condition for updating days, months
+        if yr%4 == 0:
+            # find location of 28th day of february
+            leap_day_28 = np.where(days==28)[0][5]
+            # add "29" day after Feb 28 (shifts days by 1 day); drop last day in file
+            days = np.append(np.append(days[:leap_day_28+1],29),days[leap_day_28+1:-1])
+            # add "2" day after Feb 28 (shifts months by 1 day); drop last day in file
+            months = np.append(np.append(months[:leap_day_28+1],2),months[leap_day_28+1:-1])
+            
+        years[middle_year_start:middle_year_seam_start] = yr
+        middle_year_end = np.argmax(years==1993) + int(yr%4==0) # leap year condition on the end
+        years[middle_year_seam_start:middle_year_end] = yr
+        years[middle_year_end:] = yr+1
+
+        hill['time'] = pd.to_datetime([(str(years[nt])+'-'+str(months[nt]).zfill(2)+'-'+str(days[nt]).zfill(2)) for nt in range(len(hill.day))])
+
+    hdis = hill.sel(time=slice(f'{yr-1}-12-31 12:00:00', f'{yr+1}-01-01 12:00:00')).q   
+    hill_lat = hill.lat.values
+    hill_lon = hill.lon.values
+    hill_lon[hill_lon<0]=hill_lon[hill_lon<0]+360
+        
+    #
+    outdir = sys.argv[2]
+    out_file = outdir + 'glofas_v4_hill_dis_runoff_' +str(yr) + '.nc' 
+    print('Calling Write command')
+    write_runoff(glofas, hgrid, coast, out_file)
+
+


### PR DESCRIPTION
    Two submission bash scripts to run individual years in parallel on GFDL PP/AN using slurm
    Adding specific 'write runoff' script that:
	- edits ldd file so that glofas v4 runoff from the Columbia river makes it to the coast
	- patches in Hill et al. dataset for the Gulf of Alaska for years prior to 2021 Updated river chemistry files for NEP; mapriv_combined_NEP10k.m specifically identifies river location based on glofas v4 remapping so as to reduce excessive allocation of bgc conditions beyond scope of river. Runoff is modified for large rivers where the Global NEWS/ArcticGRO/RC4USCoast value greatly exceeds glofas estimate, causing other rivers to be overwritten.