### PR TITLE
Updated envs for c5 and c6

### DIFF
--- a/builds/gaea/ncrc5.intel23.env
+++ b/builds/gaea/ncrc5.intel23.env
@@ -1,11 +1,12 @@
 source $MODULESHOME/init/tcsh
 module unload cray-netcdf cray-hdf5 fre
 module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
-module load PrgEnv-intel/8.5.0
+module load PrgEnv-intel/8.6.0
 module unload intel intel-classic intel-oneapi
 module load intel-classic/2023.2.0
-module load fre/bronx-22
-module load cray-hdf5/1.12.2.11
+module load fre/bronx-23
+module load cray-hdf5/1.14.3.5
+module load cray-netcdf/4.9.0.17
 module load libyaml/0.2.5
 module unload darshan-runtime
 module unload cray-libsci

--- a/builds/gaea/ncrc6.intel23.env
+++ b/builds/gaea/ncrc6.intel23.env
@@ -1,11 +1,12 @@
 source $MODULESHOME/init/tcsh
 module unload cray-netcdf cray-hdf5 fre
 module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu PrgEnv-cray
-module load PrgEnv-intel/8.5.0
+module load PrgEnv-intel/8.6.0
 module unload intel intel-classic intel-oneapi
 module load intel-classic/2023.2.0
-module load cray-hdf5/1.12.2.11
-module load cray-netcdf/4.9.0.9
+module load fre/bronx-23
+module load cray-hdf5/1.14.3.5
+module load cray-netcdf/4.9.0.17
 module load libyaml/0.2.5
 module unload darshan-runtime
 module unload cray-libsci


### PR DESCRIPTION
Due to recent updates to the Cray Programming Environment (CPE) on clusters c5 and c6, we’ve also updated our environment files to reflect these changes. Model builds should now work again on both c5 and c6.