### PR TITLE
Auto-update submodules to latest dev/cefi (auto/update-submodules-20250716)

### DIFF
--- a/exps/NEP10.COBALT/COBALT_parameter_doc.all
+++ b/exps/NEP10.COBALT/COBALT_parameter_doc.all
@@ -563,6 +563,8 @@ hp_ipa_det = 0.0                !   [none] default = 0.0
                                 ! innate availability of detritus to higher predator feeding (0-1)
 hp_phi_det = 0.35               !   [none] default = 0.35
                                 ! fraction of ingestion by higher predators to detritus
+frac_fastsinking = 1.0          !   [none] default = 1.0
+                                ! Fraction of N and P detritus higher predators that is fast-sinking
 half_life_14c = 5730.0          !   [s] default = 5730.0
                                 ! half_life_14c
 lambda_14c = 1.209680943385594E-04 !   [-s] default = 1.209680943385594E-04

--- a/exps/NWA12.COBALT/COBALT_parameter_doc.all
+++ b/exps/NWA12.COBALT/COBALT_parameter_doc.all
@@ -563,6 +563,8 @@ hp_ipa_det = 0.0                !   [none] default = 0.0
                                 ! innate availability of detritus to higher predator feeding (0-1)
 hp_phi_det = 0.35               !   [none] default = 0.35
                                 ! fraction of ingestion by higher predators to detritus
+frac_fastsinking = 1.0          !   [none] default = 1.0
+                                ! Fraction of N and P detritus higher predators that is fast-sinking
 half_life_14c = 5730.0          !   [s] default = 5730.0
                                 ! half_life_14c
 lambda_14c = 1.209680943385594E-04 !   [-s] default = 1.209680943385594E-04

--- a/exps/OM4.single_column.COBALT/COBALT_parameter_doc.all
+++ b/exps/OM4.single_column.COBALT/COBALT_parameter_doc.all
@@ -557,6 +557,8 @@ hp_ipa_det = 0.0                !   [none] default = 0.0
                                 ! innate availability of detritus to higher predator feeding (0-1)
 hp_phi_det = 0.35               !   [none] default = 0.35
                                 ! fraction of ingestion by higher predators to detritus
+frac_fastsinking = 1.0          !   [none] default = 1.0
+                                ! Fraction of N and P detritus higher predators that is fast-sinking
 half_life_14c = 5730.0          !   [s] default = 5730.0
                                 ! half_life_14c
 lambda_14c = 1.209680943385594E-04 !   [-s] default = 1.209680943385594E-04


### PR DESCRIPTION
This PR automatically updates the specified submodules to the latest commit on their `dev/cefi` branch.

**Updated Submodules:**

- src/ocean_BGC (updated to commit 7bc8e254f3b79f41cedbd7b86243434b72a505fe)

---
Auto-generated by GitHub Actions.