### PR TITLE
Change FTP address of 1d datasets and point users to email for other datasets

### DIFF
--- a/builds/README.md
+++ b/builds/README.md
@@ -57,6 +57,6 @@ brew install wget
 
 ## Test run: 1-D MOM6-COBALT
 - To test your `MOM6SIS2`, first navigate to the `exps` folder: `cd ../exps`
-- Download the model input files: `wget ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz`
+- Download the model input files: `wget ftp://nomads.gfdl.noaa.gov/1/users/cefi/OM4.single_column.COBALT/data/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz`
 - navigate to the 1-D example: `cd OM4.single_column.COBALT`
 - USe the following command to run the 1-D example: `mpirun -np 1 ../../builds/build/YOUR_MACHINE_DIRECTORY-NAME_OF_YOUR_mk_FILE/ocean_ice/repro/MOM6SIS2`

--- a/builds/macOS/README.md
+++ b/builds/macOS/README.md
@@ -49,6 +49,6 @@ git clone https://github.com/NOAA-GFDL/CEFI-regional-MOM6.git --recursive
 cd CEFI-regional-MOM6/builds
 ./linux-build.bash -m macOS -p osx-gnu -t repro -f mom6sis2
 cd ../exps
-wget ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz
+wget ftp://nomads.gfdl.noaa.gov/1/users/cefi/OM4.single_column.COBALT/data/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz
 cd OM4.single_column.COBALT
 mpirun -np 1 ../../builds/build/macOS-osx-gnu/ocean_ice/repro/MOM6SIS2 

--- a/ci/docker/Dockerfile.ci
+++ b/ci/docker/Dockerfile.ci
@@ -12,7 +12,7 @@ COPY --chown=builder:builder . /opt/MOM6_OBGC_examples
 
 WORKDIR /opt
 
-RUN wget ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz
+RUN wget ftp://nomads.gfdl.noaa.gov/1/users/cefi/OM4.single_column.COBALT/data/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz
 
 WORKDIR /opt/MOM6_OBGC_examples/builds
 

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -16,7 +16,7 @@ docker run --mount "type=bind,source=/Users/$USER/work,target=/work" -it 1d_mom6
 cd /work/CEFI-regional-MOM6/builds
 ./linux-build.bash -m docker -p linux-gnu -t prod -f mom6sis2
 cd ../exps
-wget ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz
+wget ftp://nomads.gfdl.noaa.gov/1/users/cefi/OM4.single_column.COBALT/data/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz
 cd OM4.single_column.COBALT
 mpirun -np 1 --allow-run-as-root ../../builds/build/docker-linux-gnu/ocean_ice/prod/MOM6SIS2
 ```

--- a/ci/singularity/README.md
+++ b/ci/singularity/README.md
@@ -15,7 +15,7 @@ singularity shell --fakeroot -B /home/$USER/work:/work -e 1d_mom6_cobalt.sif
 Singularity> cd /work/CEFI-regional-MOM6/builds
 Singularity> ./linux-build.bash -m docker -p linux-gnu -t prod -f mom6sis2
 Singularity> cd ../exps
-Singularity> wget ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz 
+Singularity> wget ftp://nomads.gfdl.noaa.gov/1/users/cefi/OM4.single_column.COBALT/data/1d_ci_datasets.tar.gz && tar -zxvf 1d_ci_datasets.tar.gz && rm -rf 1d_ci_datasets.tar.gz
 Singularity> cd OM4.single_column.COBALT
 Singularity> mpirun -np 1 --allow-run-as-root ../../builds/build/docker-linux-gnu/ocean_ice/prod/MOM6SIS2
 ```

--- a/exps/README.md
+++ b/exps/README.md
@@ -9,11 +9,12 @@ This folder contains example configurations to run MOM6-SIS2-cobalt
 | ```NWA12.COBALT/```                 | NWA12 MOM6-SIS2-cobalt example |
 | ```NEP10.COBALT/```                 | NEP10 MOM6-SIS2-cobalt example |
 
+If you do not have access to Gaea C6 and would like to run the NWA12.COBALT, NEP10.COBALT, or OM4p25.COBALT experiments, please contact us at oar.gfdl.cefi-support AT noaa DOT gov to get access to the needed datasets.
 
 # OM4.single_column.COBALT
 Users are advised to refer to the Dockerfile located at [ci/docker/Dockerfile.ci](../ci/docker/Dockerfile.ci). This Dockerfile includes the necessary steps to compile the code, download required input files, and execute the example 1D test case.
 
-Users can also test the 1D case without using the container approach, please follow [this tutorial](https://cefi-regional-mom6.readthedocs.io/en/latest/BuildMOM6.html). The example dataset for the 1D case can be downloaded from `ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/1d_ci_datasets.tar.gz`.
+Users can also test the 1D case without using the container approach, please follow [this tutorial](https://cefi-regional-mom6.readthedocs.io/en/latest/BuildMOM6.html). The example dataset for the 1D case can be downloaded from `ftp://nomads.gfdl.noaa.gov/1/users/cefi/OM4.single_column.COBALT/data/1d_ci_datasets.tar.gz`.
 
 Users can follow the instructions below to run 1D example on Gaea C5:
 
@@ -35,7 +36,6 @@ ln -fs /gpfs/f6/ira-cefi/world-shared/datasets ./
 cd OM4p25.COBALT
 sbatch driver.sh
 ```
-If users do not have access to Gaea C6, the datasets for the `OM4p25.COBALT` case be downloaded from `ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/OM4_datasets/OM4_025.JRA.tar.gz`.
 
 # NWA12.COBALT
 Users can follow the instructions below to run NWA12 example on Gaea C6.
@@ -48,7 +48,6 @@ ln -fs /gpfs/f6/ira-cefi/world-shared/datasets ./
 cd NWA12.COBALT
 sbatch run.sub 
 ```
-If users do not have access to Gaea C6, the datasets for the `NWA12` case be downloaded from `ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/nwa12_datasets.tar.gz`.
 
 # NEP10.COBALT
 Users can follow the instructions below to run NEP10 example on Gaea C6.
@@ -61,4 +60,3 @@ ln -fs /gpfs/f6/ira-cefi/world-shared/datasets ./
 cd NEP10.COBALT
 sbatch run.sub
 ```
-If users do not have access to Gaea C6, the datasets for the `NEP10` case be downloaded from `ftp.gfdl.noaa.gov:/pub/Yi-cheng.Teng/nep10_datasets.tar.gz`.


### PR DESCRIPTION
Partially addresses #251 , along with #254 . This PR updates the ftp address for the 1d data sets from Yi-Cheng's `/pub` folder to a more permanent location on GFDL's data portal. Going forward, we should point folks to that location if they want our 1d datasets

Since we rarely get requests for the other datasets and they are much larger than the 1d dataset, I updated `exps/README` to tell users to reach out to us via email if they would like the larger datasets. It may be easier to serve these individually via globus or some other solution. If anyone thinks it's important to make those datasets publicly available, I can look into a more permanent solution for those as well. 