### PR TITLE
Update CI reference answers

### DIFF
--- a/exps/NEP10.COBALT/driver.sh
+++ b/exps/NEP10.COBALT/driver.sh
@@ -101,7 +101,7 @@ mv ocean.stats RESTART_24hrs_rst
 # Define the directories containing the files
 module load nccmp
 DIR1="./RESTART_24hrs_rst"
-DIR2="/gpfs/f5/gfdl_med/proj-shared/github/ci_data/reference/main/NEP10.COBALT/20260324/" 
+DIR2="/gpfs/f5/gfdl_med/proj-shared/github/ci_data/reference/main/NEP10.COBALT/20260407" 
 
 # Define the files to compare
 FILES=("$DIR2"/MOM.res*.nc)

--- a/exps/NWA12.COBALT/driver.sh
+++ b/exps/NWA12.COBALT/driver.sh
@@ -109,7 +109,7 @@ mv ocean.stats RESTART_24hrs_rst
 # Define the directories containing the files
 module load nccmp
 DIR1="./RESTART_24hrs_rst"
-DIR2="/gpfs/f5/gfdl_med/proj-shared/github/ci_data/reference/main/NWA12.COBALT/20260324/"
+DIR2="/gpfs/f5/gfdl_med/proj-shared/github/ci_data/reference/main/NWA12.COBALT/20260407"
 
 # Define the files to compare
 FILES=("$DIR2"/*.nc)


### PR DESCRIPTION
As discussed in #232 , the new co2 forcing file changes answers slightly. This quick PR simply points the NEP and NWA driver to the new reference answers. 