### PR TITLE
Add -j flag to linux-build.bash so that builds are done in parallel

### DIFF
--- a/builds/linux-build.bash
+++ b/builds/linux-build.bash
@@ -85,7 +85,7 @@ build_libyaml() {
     pushd $srcdir/libyaml
     $srcdir/libyaml/bootstrap
     $srcdir/libyaml/configure --prefix="$target_dir" --disable-shared
-    make && make install
+    make -j && make install
     if [ $? -ne 0 ]; then
         echo "Could not build the libyaml library!"
         exit 1

--- a/builds/linux-build.bash
+++ b/builds/linux-build.bash
@@ -54,7 +54,7 @@ source $MODULESHOME/init/bash
 source $rootdir/$machine_name/$platform.env
 
 # Default Makeflags
-makeflags="NETCDF=4"
+makeflags="-j NETCDF=4"
 
 # Update makeflags based on the target
 update_makeflags() {


### PR DESCRIPTION
This PR adds the `-j` flag to `$makeflags`, so that all builds are now done in parallel. In my tests on gaea, this cut the model build time by more than half: 
Without the `-j` flag: 
```
135759991                                   MOM6SIS2_gaea_build   gfdl_med        128  COMPLETED   00:17:20 
```
With the `-j` flag:
```
135761241                          MOM6SIS2_gaea_parallel_build   gfdl_med        128  COMPLETED   00:06:58
```