### PR TITLE
Copy atmosphere forcing to INPUT/ in regression testing

### DIFF
--- a/exps/NEP10.COBALT/driver.sh
+++ b/exps/NEP10.COBALT/driver.sh
@@ -39,6 +39,20 @@ pushd ../
 ln -fs /gpfs/f5/gfdl_med/world-shared/datasets ./
 popd
 
+# UMW 05/27/2026 NOTE: For some reason, symlinking the atmosphere forcing
+# files to INPUT causes extremely slow file reads in the atmos loop, causing
+# the total runtime to ballon up to 1700 seconds. For now, copy files to
+# INPUT dir to speed up testing
+echo "Copying atmosphere forcing to INPUT dir"
+pushd INPUT
+for f in ERA5_* ; do
+    echo "Copying ${f}"
+    # readlink gets the full path to the symlinked data,
+    # cp --remove-destination removes the symlink + copies over the actual data
+    cp --remove-destination "$(readlink ${f})" ${f}
+done
+popd
+
 export img="/gpfs/f5/cefi/world-shared/container/gaea_intel_2023.2.0.sif"
 
 echo "SET MPICH_SMP_SINGLE_COPY_MODE"

--- a/exps/NEP10.COBALT/driver.sh
+++ b/exps/NEP10.COBALT/driver.sh
@@ -46,10 +46,14 @@ popd
 echo "Copying atmosphere forcing to INPUT dir"
 pushd INPUT
 for f in ERA5_* ; do
-    echo "Copying ${f}"
-    # readlink gets the full path to the symlinked data,
-    # cp --remove-destination removes the symlink + copies over the actual data
-    cp --remove-destination "$(readlink ${f})" ${f}
+    if [ -L ${f} ] ; then
+        echo "Copying ${f}"
+        # readlink gets the full path to the symlinked data,
+        # cp --remove-destination removes the symlink + copies over the actual data
+        cp --remove-destination "$(readlink ${f})" ${f}
+    else
+        echo "${f} is already copied over, skipping copy"
+    fi
 done
 popd
 

--- a/exps/NWA12.COBALT/driver.sh
+++ b/exps/NWA12.COBALT/driver.sh
@@ -47,10 +47,14 @@ popd
 echo "Copying atmosphere forcing to INPUT dir"
 pushd INPUT
 for f in ERA5_* ; do
-    echo "Copying ${f}"
-    # readlink gets the full path to the symlinked data,
-    # cp --remove-destination removes the symlink + copies over the actual data
-    cp --remove-destination "$(readlink ${f})" ${f}
+    if [ -L ${f} ] ; then
+        echo "Copying ${f}"
+        # readlink gets the full path to the symlinked data,
+        # cp --remove-destination removes the symlink + copies over the actual data
+        cp --remove-destination "$(readlink ${f})" ${f}
+    else
+        echo "${f} is already copied over, skipping copy"
+    fi
 done
 popd
 

--- a/exps/NWA12.COBALT/driver.sh
+++ b/exps/NWA12.COBALT/driver.sh
@@ -38,6 +38,22 @@ pushd ../
 ln -fs /gpfs/f5/gfdl_med/world-shared/datasets ./
 popd
 
+# UMW 05/27/2026 NOTE: For some reason, symlinking the atmosphere forcing
+# files to INPUT causes slow file reads in the atmos loop. This was a
+# bigger issue in the NEP than the NWA ( with symlinks, NWA runtime was ~800s)
+# but copying this logic here anyways
+# TODO: Ideally, we should copy over the restart files too to speed up
+# initialization, but holding off on that for now given how large they are.
+echo "Copying atmosphere forcing to INPUT dir"
+pushd INPUT
+for f in ERA5_* ; do
+    echo "Copying ${f}"
+    # readlink gets the full path to the symlinked data,
+    # cp --remove-destination removes the symlink + copies over the actual data
+    cp --remove-destination "$(readlink ${f})" ${f}
+done
+popd
+
 export img="/gpfs/f5/cefi/world-shared/container/gaea_intel_2023.2.0.sif"
 
 echo "SET MPICH_SMP_SINGLE_COPY_MODE"


### PR DESCRIPTION
Fixes #274 . It looks like the slow runtime of our atmosphere loop in the NEP was due to the symlinks to ERA5 files in `/INPUT`. This PR adds lines to the `driver.sh` script to copy the data those sym links point to the files in `INPUT/` with the same name, which dramatically speeds up the runtime of this experiment: 
```
                                      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax
Total runtime                            1    320.349794    320.359131    320.354736      0.003280  1.000     0     0  2035
ATM                                     96     43.988452     44.060401     44.051247      0.010653  0.138     0     0  2035
 ATM: atmos loop                        48     27.046917     32.091558     31.544774      1.307432  0.098     0     0  2035
  A-L: atmos_tracer_driver_gathe         0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  2035
  A-L: sfc_boundary_layer               48     18.226808     21.772154     20.949607      0.583333  0.065     0     0  2035
  A-L: update_atmos_model_dynami         0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  2035
  A-L: serial radiation                 48      0.000003      0.000025      0.000006      0.000002  0.000     0     0  2035
  A-L: update_atmos_model_down           0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  2035
  A-L: flux_down_from_atmos             48      1.441892     11.277350      5.531573      1.757310  0.017     0     0  2035
  A-L: update_land_model_fast            0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  2035
  A-L: update_ice_model_fast            48      0.009086      0.050001      0.014816      0.006321  0.000     0     0  2035
  A-L: flux_up_to_atmos                 48      0.002454      9.318037      3.045720      2.444684  0.010     0     0  2035
  A-L: update_atmos_model_up             0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  2035
  A-L: update_atmos_model_state         48      0.000004      0.000030      0.000008      0.000002  0.000     0     0  2035
Ocean                                   51    253.174053    253.534834    253.274292      0.039817  0.791     1     0  2035
```
It's not yet clear to me why #274 affected the NEP so much more than the NWA, but replacing the sym links in the NWA with copies of the ERA5 files seems to help that test case a bit as well. However, the _real_  speedup in the NWA comes from copying the restart files over as well:
```
# This run copies over both the ERA5_* forcing and the *res* files
                                      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax
Total runtime                            1    487.887857    487.915029    487.902548      0.009521  1.000     0     0  1599
Initialization                           1    162.285460    162.326663    162.296966      0.009711  0.333     0     0  1599
  Init: atmos_model_init                 1      9.182652      9.182763      9.182699      0.000034  0.019     0     0  1599
  Init: land_model_init                  1      3.635533     12.912333      8.796296      2.069088  0.018     0     0  1599
  Init: ice_model_init                   1     16.325897     16.329932     16.326175      0.000158  0.033     0     0  1599
  Init: ocean_model_init                 1     85.196948     85.200612     85.197919      0.000504  0.175     0     0  1599
  Init: flux_exchange_init               1     19.281322     19.281379     19.281359      0.000015  0.040     0     0  15
ATM                                     96     35.269438     35.579577     35.559862      0.029711  0.073     0     0  1599
 ATM: atmos loop                        48     29.624233     30.031056     29.983505      0.051970  0.061     0     0  1599
  A-L: atmos_tracer_driver_gathe         0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  1599
  A-L: sfc_boundary_layer               48     20.115309     26.461553     22.974741      2.512135  0.047     0     0  1599
  A-L: update_atmos_model_dynami         0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  1599
  A-L: serial radiation                 48      0.000003      0.000030      0.000007      0.000003  0.000     0     0  1599
  A-L: update_atmos_model_down           0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  1599
  A-L: flux_down_from_atmos             48      2.327360      9.295293      6.265547      2.454564  0.013     0     0  1599
  A-L: update_land_model_fast            0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  1599
  A-L: update_ice_model_fast            48      0.021078      0.184421      0.030818      0.017200  0.000     0     0  1599
  A-L: flux_up_to_atmos                 48      0.003310      1.070270      0.268692      0.219649  0.001     0     0  1599
  A-L: update_atmos_model_up             0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  1599
  A-L: update_atmos_model_state         48      0.000006      0.000206      0.000015      0.000014  0.000     0     0  1599
 ATM: update_land_model_slow             0      0.000000      0.000000      0.000000      0.000000  0.000     0     0  1599
 ATM: flux_land_to_ice                  48      2.643981      4.205296      3.684385      0.283376  0.008     0     0  1599
Ocean                                   51    356.451178    356.999185    356.557259      0.066444  0.731     1     0  1599
```
The `ocean_model_init` time has gone down from about ~143 seconds before down to 85 seconds. However, the restart files are large, so I'm holding off on adding that to the `driver.sh` for now, but if others think it is worth it we can add it in as well. 

To avoid copying large amounts of data, I have subset each of the  `datasets/nwa12_input/ERA_*` files down to the 50 time steps needed to run this testcase, and moved the original year long files to `datasets/nwa12_input/FULL_YEAR_ERA5`. If no one is aware of reason to keep this files in our testing directory, I may delete them.  

