### PR TITLE
Move regression testing to Gitlab

### DIFF
--- a/.github/workflows/old/CEFI_MOM6-ci.yaml
+++ b/.github/workflows/old/CEFI_MOM6-ci.yaml
@@ -1,10 +1,11 @@
 name: CEFI-MOM6-ci-c5
 
-on:
+#on:
   # Triggers this workflow on pull request event with "CEFI_MOM6_RT_container" label
-  pull_request:
-    branches: [ "main" ]
-    types: [ labeled ]
+  # UMW 06/22/2026 Update - move testing to gitlab, pause this for now
+  #pull_request:
+    #branches: [ "main" ]
+    #types: [ labeled ]
 
 #
 env:


### PR DESCRIPTION
As titled. To put CEFI in line with the testing practices used by the MOM6 group, this PR ~moves testing to a private gitlab mirror of this repo hosted here: https://gitlab.gfdl.noaa.gov/cefi/CEFI-regional-MOM6~ simply deactivates the current regression test yaml and moves it to the `.github/workflows/old` directory (EDIT: It just occurred to me that the private gitlab is not visible outside of the gfdl wifi, so my original plan to push PRs there would not have worked. I am parring back this PR to a much simpler change for now to account for this. )