### PR TITLE
Do restart file comparisons in parallel

### DIFF
--- a/exps/NEP10.COBALT/driver.sh
+++ b/exps/NEP10.COBALT/driver.sh
@@ -117,23 +117,29 @@ mv RESTART RESTART_24hrs_rst
 mv ocean.stats RESTART_24hrs_rst
 
 # Define the directories containing the files
-module load nccmp
 DIR1="./RESTART_24hrs_rst"
 DIR2="/gpfs/f5/gfdl_med/proj-shared/github/ci_data/reference/main/NEP10.COBALT/20260407" 
 
-# Define the files to compare
-FILES=("$DIR2"/MOM.res*.nc)
+# Check if gnu parallel is available
+if command -v parallel >/dev/null 2>&1 ; then
+    CMD="parallel"
+# Othwerise, use predownloaded executable
+else
+    if [ -x "/gpfs/f5/gfdl_med/world-shared/gnu_parallel/parallel" ]; then
+      CMD="/gpfs/f5/gfdl_med/world-shared/gnu_parallel/parallel"
+    elif [ -x "/gpfs/f6/ira-cefi/world-shared/gnu_parallel/parallel" ]; then
+      CMD="/gpfs/f6/ira-cefi/world-shared/gnu_parallel/parallel"
+    else
+      echo "Error: gnu parallel is not available, skipping Restart reproducibility test"
+      exit 1
+    fi
+fi
 
-# Iterate over the files
-for FILE in "${FILES[@]}"; do
-    filename=$(basename "$FILE")
-    # Compare the files using nccmp
-    echo "compare ${filename}"
-    nccmp -dfqS "${DIR1}/${filename}" "${DIR2}/${filename}" > /dev/null || { echo "Error: ${filename} is not identical, please check! Exiting now..."; exit 1; }
-done
-
-#
-echo "All restart files are identical, PASS"
+# Compare restarts in parallel
+module load nccmp
+find ${DIR1} -type f -name "*.nc" -printf "%P\n" | \
+${CMD} --halt now,fail=1 "nccmp -dfs -c 10 ${DIR1}/{} ${DIR2}/{}" \
+&& echo  "All restart files are identical, PASS"
 
 #
 if $USE_PROJ_SHARED; then

--- a/exps/NWA12.COBALT/driver.sh
+++ b/exps/NWA12.COBALT/driver.sh
@@ -127,23 +127,29 @@ mv ocean.stats RESTART_24hrs_rst
 
 
 # Define the directories containing the files
-module load nccmp
 DIR1="./RESTART_24hrs_rst"
 DIR2="/gpfs/f5/gfdl_med/proj-shared/github/ci_data/reference/main/NWA12.COBALT/20260407"
 
-# Define the files to compare
-FILES=("$DIR2"/*.nc)
+# Check if gnu parallel is available
+if command -v parallel >/dev/null 2>&1 ; then
+    CMD="parallel"
+# Othwerise, use predownloaded executable
+else
+    if [ -x "/gpfs/f5/gfdl_med/world-shared/gnu_parallel/parallel" ]; then
+      CMD="/gpfs/f5/gfdl_med/world-shared/gnu_parallel/parallel"
+    elif [ -x "/gpfs/f6/ira-cefi/world-shared/gnu_parallel/parallel" ]; then
+      CMD="/gpfs/f6/ira-cefi/world-shared/gnu_parallel/parallel"
+    else
+      echo "Error: gnu parallel is not available, skipping Restart reproducibility test"
+      exit 1
+    fi
+fi
 
-# Iterate over the files
-for FILE in "${FILES[@]}"; do
-    filename=$(basename "$FILE")	
-    # Compare the files using nccmp
-    echo "compare ${filename}"
-    nccmp -dfqS "${DIR1}/${filename}" "${DIR2}/${filename}" > /dev/null || { echo "Error: ${filename} is not identical, please check! Exiting now..."; exit 1; }
-done
-
-#
-echo "All restart files are identical, PASS"
+# Compare restarts in parallel
+module load nccmp
+find ${DIR1} -type f -name "*.nc" -printf "%P\n" | \
+${CMD} --halt now,fail=1 "nccmp -dfs -c 10 ${DIR1}/{} ${DIR2}/{}" \
+&& echo  "All restart files are identical, PASS"
 
 #
 if $USE_PROJ_SHARED; then


### PR DESCRIPTION
This PR using the gnu parallel utility to run the RESTART file comparison tests at the end of the `NEP10.COBALT` and the `NWA12.COBALT` tests in parallel. This is one of the more expensive parts of the NWA test, so hopefully it should speed up the runtime of that configuration. 