### PR TITLE
Fix a handful of minor issues in boundary condition creation workflow

### DIFF
--- a/tools/boundary/glorys_obc_workflow/mom6_obc_workflow.sh
+++ b/tools/boundary/glorys_obc_workflow/mom6_obc_workflow.sh
@@ -157,7 +157,7 @@ if ! $DO_NCRCAT; then
     	    subset_args="$subset_args --convert_lon"
 	fi
         subset_job_id=$(sbatch --job-name="glorys_subset_${year}_${month}_${day}" \
-                              scripts/subset_glorys.sh $subset_arags | awk '{print $4}')
+                              scripts/subset_glorys.sh $subset_args | awk '{print $4}')
 
         log_message "Submitting fill_nan job for $current_date..."
         fill_job_id=$(sbatch --dependency=afterok:$subset_job_id \

--- a/tools/boundary/glorys_obc_workflow/mom6_obc_workflow.sh
+++ b/tools/boundary/glorys_obc_workflow/mom6_obc_workflow.sh
@@ -83,7 +83,7 @@ fi
 
 # Prepare directories
 CURRENT_DATE=$(date +%Y-%m-%d-%H-%M)
-mkdir -p ./log/$CURRENT_DATE ./outputs scripts
+mkdir -p ./log/$CURRENT_DATE scripts
 
 # Define user configurations
 log_message "Generating config.yaml..."

--- a/tools/boundary/glorys_obc_workflow/mom6_obc_workflow.sh
+++ b/tools/boundary/glorys_obc_workflow/mom6_obc_workflow.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Load required modules and environments
-source $MODULESHOME/init/sh
+source $MODULESHOME/init/bash
 module load miniforge
 conda activate /nbhome/role.medgrp/.conda/envs/uwtools || { echo "Error activating conda environment. Exiting."; exit 1; }
 

--- a/tools/boundary/glorys_obc_workflow/template/ncrcat_obc_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/ncrcat_obc_template.sh
@@ -12,7 +12,7 @@
 
 echo "Running ncrcat_obc.sh with arguments: $@"
 
-source $MODULESHOME/init/sh
+source $MODULESHOME/init/bash
 module load miniforge
 conda activate /nbhome/role.medgrp/.conda/envs/medpy311
 module load cdo nco gcp

--- a/tools/boundary/glorys_obc_workflow/template/submit_python_make_obc_day_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/submit_python_make_obc_day_template.sh
@@ -12,7 +12,7 @@
 
 # Setup environment
 setup_environment() {
-    source $MODULESHOME/init/sh
+    source $MODULESHOME/init/bash
     module load miniforge
     conda activate /nbhome/role.medgrp/.conda/envs/medpy311
     module load cdo nco gcp

--- a/tools/boundary/glorys_obc_workflow/template/submit_python_make_obc_day_template.sh
+++ b/tools/boundary/glorys_obc_workflow/template/submit_python_make_obc_day_template.sh
@@ -66,6 +66,9 @@ main() {
     filled_dir="$glorys_arch_dir/filled"
     combined_file="$filled_dir/${OUTPUT_PREFIX}_${year}-${month}-${day}.nc"
 
+    # Make sure the output directory exists
+    mkdir -p {{ output_dir }}
+
     # Setup environment
     setup_environment
 


### PR DESCRIPTION
As titled, this fixes:
1. A typo in mom6_obc_workflow.sh
2. An error loading miniforge because of using $MODULESHOME/init/sh within a bash script
3. A bug where ./ouputs is always created even if the config sets the output dir to somewhere else (and if so, that other directory needs to be created)