### PR TITLE
Get all source code from CEFI-regional-MOM6 and share compile experiment across XMLs

### DIFF
--- a/xmls/NEP10/CEFI_NEP_cobalt.xml
+++ b/xmls/NEP10/CEFI_NEP_cobalt.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<!DOCTYPE experimentSuite [
+  <!ENTITY include_components SYSTEM "../components.xml">
+]>
 <!-- FRE Usage documentation: http://www.gfdl.noaa.gov/fms/fre -->
 <!--
 Quick start guide
@@ -34,30 +37,9 @@ frecheck -v -r restart -p ncrc6.intel23 -t repro  -x CEFI_NEP_cobalt.xml CEFI_NE
 
 
 
-<experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <!-- git tag for general component source code-->
-  <property name="RELEASE" value="2024.02"/>
-
-  <!-- git tag for FMS source code -->
-  <property name="FMS_GIT_TAG" value="2025.03"/>
-
-  <!-- git tag for coupler source code -->
-  <property name="CPL_GIT_TAG" value="2025.03"/>
-
-  <!-- git tag for null (atmos_null, land_null, etc) source code -->
-  <property name="NULL_TAG" value="2025.02"/>
-
-  <!-- git tag for ocean_shared source code -->
-  <property name="OCEAN_BGC_GIT_TAG" value="dev/cefi"/>
-
-  <!-- Updated MOM6 source code commit to checkout -->
-  <property name="MOM6_GIT_TAG" value="main"/>
-
-  <!-- Updated Icepack commit to check out -->
-  <property name="ICEPACK_GIT_TAG" value="Icepack1.3.3"/>
-
+<experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2003/XInclude">
   <!-- customize as needed -->
-  <property name="FRE_STEM" value="fre/cefi/NEP/2025_06"/>
+  <property name="FRE_STEM" value="fre/cefi/NEP/2026_07"/>
 
   <!-- Please make sure to change your group, such as b, f, g, m, o... -->
   <!-- NCRC_GROUP will only have impact for your root dir and work dir on gaea c5/c6-->
@@ -114,88 +96,34 @@ frecheck -v -r restart -p ncrc6.intel23 -t repro  -x CEFI_NEP_cobalt.xml CEFI_NE
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel23'])"/>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel25'])"/>
   </setup>
+  <!-- COMPILE -->
 
-  <!--= COMPILE =-->
-  <!--===========-->
-  <!--The property MOM6_EXAMPLES should point to the mom6 directory that is checked out. It is needed by MOM6 to access its input data files-->
-  <property name="PROG_MAIN" value="coupler/coupler_main.o"/>
-  <property name="LIBS_ROOT" value="MOM6_SIS2_GENERIC_4P_compile_symm"/>
-  <property name="FMS_LIB_DIR" value="./$(LIBS_ROOT)/$(platform)-$(target)/exec"/>
+  <!-- git tag for CEFI-regional-MOM6 source code -->
+  <property name="CEFI_GIT_TAG" value="main"/>
+  <!-- Name of the compile experiment: -->
+  <property name="COMPILE_EXP" value="FMS2_MOM6_SIS2_COBALT_compile_symm"/>
+  <!-- Insert the freInclude for each component from ../components.xml, as defined by the entity at the top -->
+  &include_components;
 
-  <property name="MY_LIBS" value="$(EXEC_ROOT)/$(FMS_LIB_DIR)"/>
-
-  <experiment name="MOM6_SIS2_GENERIC_4P_compile_symm">
+  <experiment name="$(COMPILE_EXP)">
     <description>
       Make the executable for ocean-ice experiments.
+      Each component is defined as a freInclude ultimately sourced from ../components.xml.
+      To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
+      To change individual components, delete the FMS include,
+      copy the FMS comopnent from ../compoments.xml,
+      and customize the component root or csh.
     </description>
-    <component name="fms" paths="FMS">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(FMS_GIT_TAG)"> FMS.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs>-Duse_libMPI -Duse_netCDF $(F2003_FLAGS) -DMAXFIELDMETHODS_=600</cppDefs>
-      </compile>
-    </component>
-
-    <component name="mom6_symmetric" requires="fms" paths="mom6/src/MOM6/config_src/memory/dynamic_symmetric mom6/src/MOM6/config_src/drivers/FMS_cap mom6/src/MOM6/src/*/ mom6/src/MOM6/src/*/*/ mom6/src/MOM6/config_src/external/MARBL mom6/src/MOM6/config_src/external/ODA_hooks mom6/src/MOM6/config_src/external/stochastic_physics mom6/src/MOM6/config_src/external/drifters mom6/src/MOM6/config_src/external/database_comms mom6/src/ocean_BGC/generic_tracers mom6/src/ocean_BGC/mocsy/src mom6/src/MOM6/pkg/GSW-Fortran/modules mom6/src/MOM6/pkg/GSW-Fortran/toolbox mom6/src/MOM6/config_src/infra/FMS2">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-              <codeBase version="$(MOM6_GIT_TAG)">CEFI-regional-MOM6.git </codeBase>
-        <csh><![CDATA[
-          mv CEFI-regional-MOM6 mom6
-        ]]></csh>
-      </source>
-      <compile>
-        <cppDefs><![CDATA[ $(F2003_FLAGS) -DMAX_FIELDS_=100 -DUSE_FMS2_IO -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER  -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'" ]]></cppDefs>
-        <!--makeOverrides>OPENMP=""</makeOverrides>  openmp switch for MOM6 may cause crash -->
-      </compile>
-    </component>
-
-    <component name="Icepack" paths="mom6/src/Icepack/columnphysics" requires="fms mom6_symmetric" includeDir="$root/$(LIBS_ROOT)/src/mom6/src/MOM6/src/framework" >
-      <source versionControl="git" root="https://github.com/CICE-Consortium/">
-        <codeBase version="$(ICEPACK_GIT_TAG)"> Icepack.git </codeBase>
-      </source>
-      <compile>
-         <cppDefs><![CDATA[]]></cppDefs>
-      </compile>
-    </component>
-
-    <component name="sis2" paths="mom6/src/SIS2/config_src/dynamic_symmetric mom6/src/SIS2/src mom6/src/icebergs/src mom6/src/ice_param" requires="fms mom6_symmetric Icepack" includeDir="$root/$(LIBS_ROOT)/src/mom6/src/MOM6/src/framework" >
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(RELEASE)"> ice_param.git </codeBase>
-      </source>
-      <compile>
-         <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
-      </compile>
-    </component>
-
-    <component name="land_null" paths="mom6/src/land_null" requires="fms">
-      <description domainName="NA" communityName="NA" communityVersion="NA" communityGrid="NA"/>
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(NULL_TAG)"> land_null.git </codeBase>
-      </source>
-    </component>
-
-    <component name="atmos_null" paths="mom6/src/atmos_null" requires="fms">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(NULL_TAG)"> atmos_null.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs>$(F2003_FLAGS) </cppDefs>
-      </compile>
-    </component>
-
-    <component name="coupler" paths="mom6/src/coupler/full mom6/src/coupler/shared" requires="fms land_null atmos_null sis2 mom6_symmetric">
-      <description domainName="FMS Coupler" communityName="coupler" communityVersion="$(CPL_GIT_TAG)" communityGrid=""/>
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(CPL_GIT_TAG)"> coupler.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_USE_LEGACY_LAND_ -Duse_AM3_physics -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
-      </compile>
-    </component>
+    <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='ICEPACK']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='ATMOS_NULL']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='COUPLER']/component)"/>
   </experiment>
 
-  <experiment name="CEFI_NEP_COBALT_V1" inherit="MOM6_SIS2_GENERIC_4P_compile_symm">
+  <experiment name="CEFI_NEP_COBALT_V1" inherit="$(COMPILE_EXP)">
     <description>
       Base MOM6-NEP BGC hindcast.
       Based on NEP_cefi_bgc_burial config
@@ -716,7 +644,7 @@ COBALT_INPUT_EOF
          cp diag_table input.nml metadata.out/
          cp INPUT/*_input INPUT/*_override metadata.out/
          # Save the Git commit hash for each source code submodule
-         git -C $root/$(LIBS_ROOT)/src/mom6 submodule status --recursive > metadata.out/git_submodule_status
+         git -C $root/$(COMPILE_EXP)/src/.CEFI-regional-MOM6 submodule status --recursive > metadata.out/git_submodule_status
          # Archive a copy of the xml used to run the model and the run script (fre sets these)
          cp $rtsxml metadata.out/
          cp $scriptName metadata.out/runscript.csh

--- a/xmls/NEP10/CEFI_NEP_cobalt.xml
+++ b/xmls/NEP10/CEFI_NEP_cobalt.xml
@@ -111,7 +111,7 @@ frecheck -v -r restart -p ncrc6.intel23 -t repro  -x CEFI_NEP_cobalt.xml CEFI_NE
       Each component is defined as a freInclude ultimately sourced from ../components.xml.
       To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
       To change individual components, delete the FMS include,
-      copy the FMS comopnent from ../compoments.xml,
+      copy the FMS comopnent from ../components.xml,
       and customize the component root or csh.
     </description>
     <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>

--- a/xmls/NEP10/CEFI_NEP_cobalt.xml
+++ b/xmls/NEP10/CEFI_NEP_cobalt.xml
@@ -14,14 +14,14 @@ module use /ncrc/home2/fms/local/modulefiles
 module load fre/bronx-23
 
 C5:
-fremake -x CEFI_NEP_cobalt.xml -p ncrc5.intel23 -t repro MOM6_SIS2_GENERIC_4P_compile_symm
+fremake -x CEFI_NEP_cobalt.xml -p ncrc5.intel23 -t repro FMS2_MOM6_SIS2_COBALT_compile_symm
 frerun  -x CEFI_NEP_cobalt.xml -p ncrc5.intel23 -t repro CEFI_NEP_COBALT_V1
 
 Regression test
 frerun -x CEFI_NEP_cobalt.xml -p ncrc5.intel23 -q debug -r test -t repro CEFI_NEP_COBALT_V1
 
 C6:
-fremake -x CEFI_NEP_cobalt.xml -p ncrc6.intel23 -t repro MOM6_SIS2_GENERIC_4P_compile_symm
+fremake -x CEFI_NEP_cobalt.xml -p ncrc6.intel23 -t repro FMS2_MOM6_SIS2_COBALT_compile_symm
 frerun  -x CEFI_NEP_cobalt.xml -p ncrc6.intel23 -t repro CEFI_NEP_COBALT_V1
 
 pp (on PPAN):

--- a/xmls/NEP10/CEFI_NEP_cobalt.xml
+++ b/xmls/NEP10/CEFI_NEP_cobalt.xml
@@ -115,7 +115,7 @@ frecheck -v -r restart -p ncrc6.intel23 -t repro  -x CEFI_NEP_cobalt.xml CEFI_NE
       and customize the component root or csh.
     </description>
     <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>
-    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_BGC']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='ICEPACK']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
@@ -550,7 +550,7 @@ cat > $work/INPUT/MOM_override << MOM_OVERRIDE_EOF
 #override U_TRUNC_FILE = "U.velocity_truncations"
 #override V_TRUNC_FILE = "V.velocity_truncations"
 #override TIDES_ANSWER_DATE = 20230630
-#override WAVE_INTERFACE_ANSWER_DATE = 20221231 
+#override WAVE_INTERFACE_ANSWER_DATE = 20221231
 #override MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = False
 MOM_OVERRIDE_EOF
 

--- a/xmls/NWA12/CEFI_NWA12_cobalt.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt.xml
@@ -119,7 +119,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
       and customize the component root or csh.
     </description>
     <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>
-    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_BGC']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='ATMOS_NULL']/component)"/>

--- a/xmls/NWA12/CEFI_NWA12_cobalt.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt.xml
@@ -13,7 +13,7 @@ module use -a /ncrc/home2/fms/local/modulefiles
 module load fre/bronx-23
 
 Compile and build mom6-sis2-cobalt:
-fremake -x CEFI_NWA12_cobalt.xml -p ncrc6.intel23 -t prod,hdf5 MOM6_SIS2_GENERIC_4P_compile_symm
+fremake -x CEFI_NWA12_cobalt.xml -p ncrc6.intel23 -t prod,hdf5 FMS2_MOM6_SIS2_COBALT_compile_symm
 
 Run experiment
 frerun -x CEFI_NWA12_cobalt.xml -p ncrc6.intel23 -t prod,hdf5 CEFI_NWA12_COBALT_V2
@@ -36,23 +36,11 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
 -->
 
 <experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <!-- git tag for FMS source code -->
-  <property name="FMS_GIT_TAG" value="2025.03"/>
-
-  <!-- git tag for shared source code -->
-  <property name="CPL_GIT_TAG" value="2025.03"/>
-
-  <!-- git tag for null model source code -->
-  <property name="NULL_TAG" value="2025.02"/>
-
   <!-- git tag for CEFI-regional-MOM6 source code -->
-  <property name="MOM6_GIT_TAG" value="main"/>
-
-  <!-- git tag for ice_param -->
-  <property name="ICEPARAM_GIT_TAG" value="2024.02"/>
+  <property name="CEFI_GIT_TAG" value="main"/>
 
   <!-- This will be included in the paths to the compiled model binary and /archive. Customize as desired.-->
-  <property name="FRE_STEM" value="fre/cefi/NWA/2025_06"/>
+  <property name="FRE_STEM" value="fre/cefi/NWA/2026_07"/>
 
   <!-- Please make sure to change your group, such as b, f, g, m, o... -->
   <property name="NCRC_GROUP" value="ira-cefi"/>
@@ -112,71 +100,77 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel25'])"/>
   </setup>
 
-  <!--= COMPILE =-->
-  <!--===========-->
-  <!--The property MOM6_OBGC_EXAMPLES should point to the mom6 directory that is checked out. It is needed by MOM6 to access its input data files-->
-  <property name="PROG_MAIN" value="coupler/coupler_main.o"/>
-  <property name="LIBS_ROOT" value="MOM6_SIS2_GENERIC_4P_compile_symm"/>
-  <property name="FMS_LIB_DIR" value="./$(LIBS_ROOT)/$(platform)-$(target)/exec"/>
+  <!-- COMPILE -->
 
-  <property name="MY_LIBS" value="$(EXEC_ROOT)/$(FMS_LIB_DIR)"/>
+  <property name="PROG_MAIN" value="FMScoupler/coupler_main.o"/>
+  <property name="LIBS_ROOT" value="FMS2_MOM6_SIS2_COBALT_compile_symm"/>
 
-  <experiment name="MOM6_SIS2_GENERIC_4P_compile_symm">
+  <experiment name="$(LIBS_ROOT)">
     <description>
       Make the executable for ocean-ice experiments.
-      Uses FMS2 (for unknown reason FMS1 does not work with intel23 on C6)
     </description>
     <component name="fms" paths="FMS">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(FMS_GIT_TAG)"> FMS.git </codeBase>
+      <!-- The FMS component clones the CEFI-regional-MOM6 repository, which includes
+      submodules for every component. All of the following components will
+      use these submodules, so we place symlinks to them in a slightly easier
+      to find location. All of the components after this have a
+      source block that doesn't do anything, since the code has already been obtained.
+      (Note that because the placeholder source blocks don't do anything,
+      csh blocks cannot be added to them.) -->
+      <source versionControl="git" root="https://github.com/NOAA-GFDL/">
+        <codeBase version="$(CEFI_GIT_TAG)">CEFI-regional-MOM6.git</codeBase>
+        <csh><![CDATA[
+          # Hide the CEFI-regional-MOM6 repository and put links to the
+          # source code submodules in the top level src/ directory
+          mv CEFI-regional-MOM6 .CEFI-regional-MOM6
+          foreach subpath ( .CEFI-regional-MOM6/src/* )
+            if ( -d "$subpath" ) then
+              ln -s $subpath .
+            endif
+          end
+        ]]></csh>
       </source>
       <compile>
         <cppDefs>-Duse_libMPI -Duse_netCDF $(F2003_FLAGS) -DMAXFIELDMETHODS_=600</cppDefs>
       </compile>
     </component>
 
-    <component name="mom6_symmetric" requires="fms" paths="mom6/src/MOM6/config_src/memory/dynamic_symmetric mom6/src/MOM6/config_src/drivers/FMS_cap mom6/src/MOM6/src/*/ mom6/src/MOM6/src/*/*/ mom6/src/MOM6/config_src/external/MARBL mom6/src/MOM6/config_src/external/ODA_hooks mom6/src/MOM6/config_src/external/stochastic_physics mom6/src/MOM6/config_src/external/drifters mom6/src/MOM6/config_src/external/database_comms mom6/src/ocean_BGC/generic_tracers mom6/src/ocean_BGC/mocsy/src mom6/src/MOM6/pkg/GSW-Fortran/modules mom6/src/MOM6/pkg/GSW-Fortran/toolbox mom6/src/MOM6/config_src/infra/FMS2">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-              <codeBase version="$(MOM6_GIT_TAG)"> CEFI-regional-MOM6.git </codeBase>
-        <csh><![CDATA[
-          mv CEFI-regional-MOM6 mom6
-        ]]></csh>
+    <component name="mom6_symmetric" requires="fms" paths="MOM6/config_src/memory/dynamic_symmetric MOM6/config_src/drivers/FMS_cap MOM6/src/*/ MOM6/src/*/*/ MOM6/config_src/external/MARBL MOM6/config_src/external/ODA_hooks MOM6/config_src/external/stochastic_physics MOM6/config_src/external/drifters MOM6/config_src/external/database_comms ocean_BGC/generic_tracers ocean_BGC/mocsy/src MOM6/pkg/GSW-Fortran/modules MOM6/pkg/GSW-Fortran/toolbox MOM6/config_src/infra/FMS2">
+      <source versionControl="none" root=".">
+        <codeBase version="none"> placeholder </codeBase>
       </source>
       <compile>
-        <cppDefs><![CDATA[ $(F2003_FLAGS) -DUSE_FMS2_IO -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER  -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'" ]]></cppDefs>
-        <!--makeOverrides>OPENMP=""</makeOverrides>  openmp switch for MOM6 may cause crash -->
+        <cppDefs><![CDATA[ $(F2003_FLAGS) -DUSE_FMS2_IO -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'" ]]></cppDefs>
       </compile>
     </component>
 
-    <component name="sis2" paths="mom6/src/SIS2/config_src/dynamic_symmetric mom6/src/SIS2/config_src/external/Icepack_interfaces mom6/src/SIS2/src mom6/src/icebergs/src mom6/src/ice_param" requires="fms mom6_symmetric" includeDir="$root/$(LIBS_ROOT)/src/mom6/src/MOM6/src/framework" >
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(ICEPARAM_GIT_TAG)"> ice_param.git </codeBase>
+    <component name="sis2" paths="SIS2/config_src/dynamic_symmetric SIS2/config_src/external/Icepack_interfaces SIS2/src icebergs/src ice_param" requires="fms mom6_symmetric" includeDir="$root/$(LIBS_ROOT)/src/MOM6/src/framework">
+      <source versionControl="none" root=".">
+        <codeBase version="none"> placeholder </codeBase>
       </source>
       <compile>
          <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
       </compile>
     </component>
 
-    <component name="land_null" paths="mom6/src/land_null" requires="fms">
-      <description domainName="NA" communityName="NA" communityVersion="NA" communityGrid="NA"/>
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(NULL_TAG)"> land_null.git </codeBase>
+    <component name="land_null" paths="land_null" requires="fms">
+      <source versionControl="none" root=".">
+        <codeBase version="none"> placeholder </codeBase>
       </source>
     </component>
 
-    <component name="atmos_null" paths="mom6/src/atmos_null" requires="fms">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(NULL_TAG)"> atmos_null.git </codeBase>
+    <component name="atmos_null" paths="atmos_null" requires="fms">
+      <source versionControl="none" root=".">
+        <codeBase version="none"> placeholder </codeBase>
       </source>
       <compile>
         <cppDefs>$(F2003_FLAGS) </cppDefs>
       </compile>
     </component>
 
-    <component name="coupler" paths="mom6/src/coupler/full mom6/src/coupler/shared" requires="fms land_null atmos_null sis2 mom6_symmetric">
-      <description domainName="FMS Coupler" communityName="coupler" communityVersion="$(CPL_GIT_TAG)" communityGrid=""/>
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(CPL_GIT_TAG)"> coupler.git </codeBase>
+    <component name="coupler" paths="coupler/full coupler/shared" requires="fms land_null atmos_null sis2 mom6_symmetric">
+      <source versionControl="none" root=".">
+        <codeBase version="none"> placeholder </codeBase>
       </source>
       <compile>
         <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_USE_LEGACY_LAND_ -Duse_AM3_physics -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
@@ -184,7 +178,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
     </component>
   </experiment>
 
-  <experiment name="CEFI_NWA12_COBALT_V2" inherit="MOM6_SIS2_GENERIC_4P_compile_symm">
+  <experiment name="CEFI_NWA12_COBALT_V2" inherit="$(LIBS_ROOT)">
     <description>
     </description>
     <input>
@@ -715,7 +709,7 @@ COBALT_INPUT_EOF
          cp diag_table input.nml metadata.out/
          cp INPUT/*_input INPUT/*_override metadata.out/
          # Save the Git commit hash for each source code submodule
-         git -C $root/$(LIBS_ROOT)/src/mom6 submodule status --recursive > metadata.out/git_submodule_status
+         git -C $root/$(LIBS_ROOT)/src/.CEFI-regional-MOM6 submodule status --recursive > metadata.out/git_submodule_status
          # Archive a copy of the xml used to run the model and the run script (fre sets these)
          cp $rtsxml metadata.out/
          cp $scriptName metadata.out/runscript.csh

--- a/xmls/NWA12/CEFI_NWA12_cobalt.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt.xml
@@ -115,7 +115,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
       Each component is defined as a freInclude ultimately sourced from ../components.xml.
       To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
       To change individual components, delete the FMS include,
-      copy the FMS comopnent from ../compoments.xml,
+      copy the FMS comopnent from ../components.xml,
       and customize the component root or csh.
     </description>
     <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>

--- a/xmls/NWA12/CEFI_NWA12_cobalt.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<!DOCTYPE experimentSuite [
+  <!ENTITY include_components SYSTEM "../components.xml">
+]>
 <!-- FRE Usage documentation: http://www.gfdl.noaa.gov/fms/fre -->
 <!--
 Quick start guide
@@ -35,10 +38,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
 
 -->
 
-<experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <!-- git tag for CEFI-regional-MOM6 source code -->
-  <property name="CEFI_GIT_TAG" value="main"/>
-
+<experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2003/XInclude">
   <!-- This will be included in the paths to the compiled model binary and /archive. Customize as desired.-->
   <property name="FRE_STEM" value="fre/cefi/NWA/2026_07"/>
 
@@ -102,83 +102,31 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt.xml CEFI_NWA12_COBALT_V
 
   <!-- COMPILE -->
 
-  <property name="PROG_MAIN" value="FMScoupler/coupler_main.o"/>
-  <property name="LIBS_ROOT" value="FMS2_MOM6_SIS2_COBALT_compile_symm"/>
+  <!-- git tag for CEFI-regional-MOM6 source code -->
+  <property name="CEFI_GIT_TAG" value="main"/>
+  <!-- Name of the compile experiment: -->
+  <property name="COMPILE_EXP" value="FMS2_MOM6_SIS2_COBALT_compile_symm"/>
+  <!-- Insert the freInclude for each component from ../components.xml, as defined by the entity at the top -->
+  &include_components;
 
-  <experiment name="$(LIBS_ROOT)">
+  <experiment name="$(COMPILE_EXP)">
     <description>
       Make the executable for ocean-ice experiments.
+      Each component is defined as a freInclude ultimately sourced from ../components.xml.
+      To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
+      To change individual components, delete the FMS include,
+      copy the FMS comopnent from ../compoments.xml,
+      and customize the component root or csh.
     </description>
-    <component name="fms" paths="FMS">
-      <!-- The FMS component clones the CEFI-regional-MOM6 repository, which includes
-      submodules for every component. All of the following components will
-      use these submodules, so we place symlinks to them in a slightly easier
-      to find location. All of the components after this have a
-      source block that doesn't do anything, since the code has already been obtained.
-      (Note that because the placeholder source blocks don't do anything,
-      csh blocks cannot be added to them.) -->
-      <source versionControl="git" root="https://github.com/NOAA-GFDL/">
-        <codeBase version="$(CEFI_GIT_TAG)">CEFI-regional-MOM6.git</codeBase>
-        <csh><![CDATA[
-          # Hide the CEFI-regional-MOM6 repository and put links to the
-          # source code submodules in the top level src/ directory
-          mv CEFI-regional-MOM6 .CEFI-regional-MOM6
-          foreach subpath ( .CEFI-regional-MOM6/src/* )
-            if ( -d "$subpath" ) then
-              ln -s $subpath .
-            endif
-          end
-        ]]></csh>
-      </source>
-      <compile>
-        <cppDefs>-Duse_libMPI -Duse_netCDF $(F2003_FLAGS) -DMAXFIELDMETHODS_=600</cppDefs>
-      </compile>
-    </component>
-
-    <component name="mom6_symmetric" requires="fms" paths="MOM6/config_src/memory/dynamic_symmetric MOM6/config_src/drivers/FMS_cap MOM6/src/*/ MOM6/src/*/*/ MOM6/config_src/external/MARBL MOM6/config_src/external/ODA_hooks MOM6/config_src/external/stochastic_physics MOM6/config_src/external/drifters MOM6/config_src/external/database_comms ocean_BGC/generic_tracers ocean_BGC/mocsy/src MOM6/pkg/GSW-Fortran/modules MOM6/pkg/GSW-Fortran/toolbox MOM6/config_src/infra/FMS2">
-      <source versionControl="none" root=".">
-        <codeBase version="none"> placeholder </codeBase>
-      </source>
-      <compile>
-        <cppDefs><![CDATA[ $(F2003_FLAGS) -DUSE_FMS2_IO -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'" ]]></cppDefs>
-      </compile>
-    </component>
-
-    <component name="sis2" paths="SIS2/config_src/dynamic_symmetric SIS2/config_src/external/Icepack_interfaces SIS2/src icebergs/src ice_param" requires="fms mom6_symmetric" includeDir="$root/$(LIBS_ROOT)/src/MOM6/src/framework">
-      <source versionControl="none" root=".">
-        <codeBase version="none"> placeholder </codeBase>
-      </source>
-      <compile>
-         <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
-      </compile>
-    </component>
-
-    <component name="land_null" paths="land_null" requires="fms">
-      <source versionControl="none" root=".">
-        <codeBase version="none"> placeholder </codeBase>
-      </source>
-    </component>
-
-    <component name="atmos_null" paths="atmos_null" requires="fms">
-      <source versionControl="none" root=".">
-        <codeBase version="none"> placeholder </codeBase>
-      </source>
-      <compile>
-        <cppDefs>$(F2003_FLAGS) </cppDefs>
-      </compile>
-    </component>
-
-    <component name="coupler" paths="coupler/full coupler/shared" requires="fms land_null atmos_null sis2 mom6_symmetric">
-      <source versionControl="none" root=".">
-        <codeBase version="none"> placeholder </codeBase>
-      </source>
-      <compile>
-        <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_USE_LEGACY_LAND_ -Duse_AM3_physics -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
-      </compile>
-    </component>
+    <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='ATMOS_NULL']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='COUPLER']/component)"/>
   </experiment>
 
-  <experiment name="CEFI_NWA12_COBALT_V2" inherit="$(LIBS_ROOT)">
+  <experiment name="CEFI_NWA12_COBALT_V2" inherit="$(COMPILE_EXP)">
     <description>
     </description>
     <input>
@@ -709,7 +657,7 @@ COBALT_INPUT_EOF
          cp diag_table input.nml metadata.out/
          cp INPUT/*_input INPUT/*_override metadata.out/
          # Save the Git commit hash for each source code submodule
-         git -C $root/$(LIBS_ROOT)/src/.CEFI-regional-MOM6 submodule status --recursive > metadata.out/git_submodule_status
+         git -C $root/$(COMPILE_EXP)/src/.CEFI-regional-MOM6 submodule status --recursive > metadata.out/git_submodule_status
          # Archive a copy of the xml used to run the model and the run script (fre sets these)
          cp $rtsxml metadata.out/
          cp $scriptName metadata.out/runscript.csh

--- a/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
@@ -143,7 +143,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt_fms2_yaml.xml CEFI_NWA1
         <cppDefs>-Duse_yaml -Duse_libMPI -Duse_netCDF $(F2003_FLAGS) -DMAXFIELDMETHODS_=600</cppDefs>
       </compile>
     </component>
-    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_BGC']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='ATMOS_NULL']/component)"/>

--- a/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
@@ -115,7 +115,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt_fms2_yaml.xml CEFI_NWA1
       Each component is defined as a freInclude ultimately sourced from ../components.xml.
       To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
       To change individual components, delete the FMS include,
-      copy the FMS comopnent from ../compoments.xml,
+      copy the FMS comopnent from ../components.xml,
       and customize the component root or csh.
       This experiment uses a different cppDefs for the FMS component and
       illustrates how to change this component.

--- a/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
+++ b/xmls/NWA12/CEFI_NWA12_cobalt_fms2_yaml.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<!DOCTYPE experimentSuite [
+  <!ENTITY include_components SYSTEM "../components.xml">
+]>
 <!-- FRE Usage documentation: http://www.gfdl.noaa.gov/fms/fre -->
 <!--
 Quick start guide
@@ -13,7 +16,7 @@ module use -a /ncrc/home2/fms/local/modulefiles
 module load fre/bronx-23
 
 Compile and build mom6-sis2-cobalt:
-fremake -x CEFI_NWA12_cobalt_fms2_yaml.xml -p ncrc6.intel23 -t prod,hdf5 MOM6_SIS2_GENERIC_4P_compile_symm_yaml
+fremake -x CEFI_NWA12_cobalt_fms2_yaml.xml -p ncrc6.intel23 -t prod,hdf5 FMS2_yaml_MOM6_SIS2_COBALT_compile_symm
 
 Run experiment
 frerun -x CEFI_NWA12_cobalt_fms2_yaml.xml -p ncrc6.intel23 -t prod,hdf5 CEFI_NWA12_COBALT_yaml_V2
@@ -35,24 +38,9 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt_fms2_yaml.xml CEFI_NWA1
 
 -->
 
-<experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <!-- git tag for FMS source code -->
-  <property name="FMS_GIT_TAG" value="2025.03"/>
-
-  <!-- git tag for shared source code -->
-  <property name="CPL_GIT_TAG" value="2025.03"/>
-
-  <!-- git tag for null model source code -->
-  <property name="NULL_TAG" value="2025.02"/>
-
-  <!-- git tag for CEFI-regional-MOM6 source code -->
-  <property name="MOM6_GIT_TAG" value="main"/>
-
-  <!-- git tag for ice_param -->
-  <property name="ICEPARAM_GIT_TAG" value="2024.02"/>
-
+<experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2003/XInclude">
   <!-- This will be included in the paths to the compiled model binary and /archive. Customize as desired.-->
-  <property name="FRE_STEM" value="fre/cefi/NWA/2025_04"/>
+  <property name="FRE_STEM" value="fre/cefi/NWA/2026_07"/>
 
   <!-- Please make sure to change your group, such as b, f, g, m, o... -->
   <property name="NCRC_GROUP" value="ira-cefi"/>
@@ -112,79 +100,57 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_cobalt_fms2_yaml.xml CEFI_NWA1
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel25'])"/>
   </setup>
 
-  <!--= COMPILE =-->
-  <!--===========-->
-  <!--The property MOM6_OBGC_EXAMPLES should point to the mom6 directory that is checked out. It is needed by MOM6 to access its input data files-->
-  <property name="PROG_MAIN" value="coupler/coupler_main.o"/>
-  <property name="LIBS_ROOT" value="MOM6_SIS2_GENERIC_4P_compile_symm_yaml"/>
-  <property name="FMS_LIB_DIR" value="./$(LIBS_ROOT)/$(platform)-$(target)/exec"/>
+  <!-- COMPILE -->
 
-  <property name="MY_LIBS" value="$(EXEC_ROOT)/$(FMS_LIB_DIR)"/>
+  <!-- git tag for CEFI-regional-MOM6 source code -->
+  <property name="CEFI_GIT_TAG" value="main"/>
+  <!-- Name of the compile experiment: -->
+  <property name="COMPILE_EXP" value="FMS2_yaml_MOM6_SIS2_COBALT_compile_symm"/>
+  <!-- Insert the freInclude for each component from ../components.xml, as defined by the entity at the top -->
+  &include_components;
 
-  <experiment name="MOM6_SIS2_GENERIC_4P_compile_symm_yaml">
+  <experiment name="$(COMPILE_EXP)">
     <description>
       Make the executable for ocean-ice experiments.
-      Uses FMS2 (for unknown reason FMS1 does not work with intel23 on C6)
+      Each component is defined as a freInclude ultimately sourced from ../components.xml.
+      To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
+      To change individual components, delete the FMS include,
+      copy the FMS comopnent from ../compoments.xml,
+      and customize the component root or csh.
+      This experiment uses a different cppDefs for the FMS component and
+      illustrates how to change this component.
     </description>
     <component name="fms" paths="FMS">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(FMS_GIT_TAG)"> FMS.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs>-Duse_yaml -Duse_libMPI -Duse_netCDF $(F2003_FLAGS) -DMAXFIELDMETHODS_=600</cppDefs>
-      </compile>
-    </component>
-
-    <component name="mom6_symmetric" requires="fms" paths="mom6/src/MOM6/config_src/memory/dynamic_symmetric mom6/src/MOM6/config_src/drivers/FMS_cap mom6/src/MOM6/src/*/ mom6/src/MOM6/src/*/*/ mom6/src/MOM6/config_src/external/MARBL mom6/src/MOM6/config_src/external/ODA_hooks mom6/src/MOM6/config_src/external/stochastic_physics mom6/src/MOM6/config_src/external/drifters mom6/src/MOM6/config_src/external/database_comms mom6/src/ocean_BGC/generic_tracers mom6/src/ocean_BGC/mocsy/src mom6/src/MOM6/pkg/GSW-Fortran/modules mom6/src/MOM6/pkg/GSW-Fortran/toolbox mom6/src/MOM6/config_src/infra/FMS2">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-              <codeBase version="$(MOM6_GIT_TAG)"> CEFI-regional-MOM6.git </codeBase>
+      <!-- The FMS component clones the CEFI-regional-MOM6 repository, which includes
+      submodules for every component. All of the following components will
+      use these submodules, so we place symlinks to them in a slightly easier
+      to find location. -->
+      <source versionControl="git" root="https://github.com/NOAA-GFDL/">
+        <codeBase version="$(CEFI_GIT_TAG)">CEFI-regional-MOM6.git</codeBase>
         <csh><![CDATA[
-          mv CEFI-regional-MOM6 mom6
+            # Hide the CEFI-regional-MOM6 repository and put links to the
+            # source code submodules in the top level src/ directory
+            mv CEFI-regional-MOM6 .CEFI-regional-MOM6
+            foreach subpath ( .CEFI-regional-MOM6/src/* )
+            if ( -d "$subpath" ) then
+                ln -s $subpath .
+            endif
+            end
         ]]></csh>
       </source>
       <compile>
-        <cppDefs><![CDATA[ $(F2003_FLAGS) -DMAX_FIELDS_=100 -DUSE_FMS2_IO -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER  -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'" ]]></cppDefs>
-        <!--makeOverrides>OPENMP=""</makeOverrides>  openmp switch for MOM6 may cause crash -->
+        <!-- This experiment includes the -Duse_yaml flag -->
+        <cppDefs>-Duse_yaml -Duse_libMPI -Duse_netCDF $(F2003_FLAGS) -DMAXFIELDMETHODS_=600</cppDefs>
       </compile>
     </component>
-
-    <component name="sis2" paths="mom6/src/SIS2/config_src/dynamic_symmetric mom6/src/SIS2/config_src/external/Icepack_interfaces mom6/src/SIS2/src mom6/src/icebergs/src mom6/src/ice_param" requires="fms mom6_symmetric" includeDir="$root/$(LIBS_ROOT)/src/mom6/src/MOM6/src/framework" >
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(ICEPARAM_GIT_TAG)"> ice_param.git </codeBase>
-      </source>
-      <compile>
-         <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
-      </compile>
-    </component>
-
-    <component name="land_null" paths="mom6/src/land_null" requires="fms">
-      <description domainName="NA" communityName="NA" communityVersion="NA" communityGrid="NA"/>
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(NULL_TAG)"> land_null.git </codeBase>
-      </source>
-    </component>
-
-    <component name="atmos_null" paths="mom6/src/atmos_null" requires="fms">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(NULL_TAG)"> atmos_null.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs>$(F2003_FLAGS) </cppDefs>
-      </compile>
-    </component>
-
-    <component name="coupler" paths="mom6/src/coupler/full mom6/src/coupler/shared" requires="fms land_null atmos_null sis2 mom6_symmetric">
-      <description domainName="FMS Coupler" communityName="coupler" communityVersion="$(CPL_GIT_TAG)" communityGrid=""/>
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(CPL_GIT_TAG)"> coupler.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_USE_LEGACY_LAND_ -Duse_AM3_physics -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
-      </compile>
-    </component>
+    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='ATMOS_NULL']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='COUPLER']/component)"/>
   </experiment>
 
-  <experiment name="CEFI_NWA12_COBALT_yaml_V2" inherit="MOM6_SIS2_GENERIC_4P_compile_symm_yaml">
+  <experiment name="CEFI_NWA12_COBALT_yaml_V2" inherit="$(COMPILE_EXP)">
     <description>
     </description>
     <input>
@@ -716,7 +682,7 @@ COBALT_INPUT_EOF
          cp diag_table input.nml metadata.out/
          cp INPUT/*_input INPUT/*_override metadata.out/
          # Save the Git commit hash for each source code submodule
-         git -C $root/$(LIBS_ROOT)/src/mom6 submodule status --recursive > metadata.out/git_submodule_status
+         git -C $root/$(COMPILE_EXP)/src/.CEFI-regional-MOM6 submodule status --recursive > metadata.out/git_submodule_status
          # Archive a copy of the xml used to run the model and the run script (fre sets these)
          cp $rtsxml metadata.out/
          cp $scriptName metadata.out/runscript.csh

--- a/xmls/NWA12/CEFI_NWA12_physics.xml
+++ b/xmls/NWA12/CEFI_NWA12_physics.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<!DOCTYPE experimentSuite [
+  <!ENTITY include_components SYSTEM "../components.xml">
+]>
 <!-- FRE Usage documentation: http://www.gfdl.noaa.gov/fms/fre -->
 <!--
 Quick start guide
@@ -13,7 +16,7 @@ module use -a /ncrc/home2/fms/local/modulefiles
 module load fre/bronx-23
 
 Compile and build mom6-sis2-cobalt:
-fremake -x CEFI_NWA12_physics.xml -p ncrc6.intel23 -t prod,hdf5 MOM6_SIS2_GENERIC_4P_compile_symm
+fremake -x CEFI_NWA12_physics.xml -p ncrc6.intel23 -t prod,hdf5 FMS2_MOM6_SIS2_COBALT_compile_symm
 
 Run experiment
 frerun -x CEFI_NWA12_physics.xml -p ncrc6.intel23 -t prod,hdf5 CEFI_NWA12_physics_V2
@@ -35,24 +38,9 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_physics.xml CEFI_NWA12_physics
 
 -->
 
-<experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <!-- git tag for FMS source code -->
-  <property name="FMS_GIT_TAG" value="2025.03"/>
-
-  <!-- git tag for shared source code -->
-  <property name="CPL_GIT_TAG" value="2025.03"/>
-
-  <!-- git tag for null model source code -->
-  <property name="NULL_TAG" value="2025.02"/>
-
-  <!-- git tag for CEFI-regional-MOM6 source code -->
-  <property name="MOM6_GIT_TAG" value="main"/>
-
-  <!-- git tag for ice_param -->
-  <property name="ICEPARAM_GIT_TAG" value="2024.02"/>
-
+<experimentSuite rtsVersion="4" xmlns:xi="http://www.w3.org/2003/XInclude">
   <!-- This will be included in the paths to the compiled model binary and /archive. Customize as desired.-->
-  <property name="FRE_STEM" value="fre/cefi/NWA/2025_06"/>
+  <property name="FRE_STEM" value="fre/cefi/NWA/2026_07"/>
 
   <!-- Please make sure to change your group, such as b, f, g, m, o... -->
   <property name="NCRC_GROUP" value="ira-cefi"/>
@@ -108,79 +96,33 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_physics.xml CEFI_NWA12_physics
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel23'])"/>
   </setup>
 
-  <!--= COMPILE =-->
-  <!--===========-->
-  <!--The property MOM6_OBGC_EXAMPLES should point to the mom6 directory that is checked out. It is needed by MOM6 to access its input data files-->
-  <property name="PROG_MAIN" value="coupler/coupler_main.o"/>
-  <property name="LIBS_ROOT" value="MOM6_SIS2_GENERIC_4P_compile_symm"/>
-  <property name="FMS_LIB_DIR" value="./$(LIBS_ROOT)/$(platform)-$(target)/exec"/>
+  <!-- COMPILE -->
 
-  <property name="MY_LIBS" value="$(EXEC_ROOT)/$(FMS_LIB_DIR)"/>
+  <!-- git tag for CEFI-regional-MOM6 source code -->
+  <property name="CEFI_GIT_TAG" value="main"/>
+  <!-- Name of the compile experiment: -->
+  <property name="COMPILE_EXP" value="FMS2_MOM6_SIS2_COBALT_compile_symm"/>
+  <!-- Insert the freInclude for each component from ../components.xml, as defined by the entity at the top -->
+  &include_components;
 
-  <experiment name="MOM6_SIS2_GENERIC_4P_compile_symm">
+  <experiment name="$(COMPILE_EXP)">
     <description>
       Make the executable for ocean-ice experiments.
-      Uses FMS2 (for unknown reason FMS1 does not work with intel23 on C6)
+      Each component is defined as a freInclude ultimately sourced from ../components.xml.
+      To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
+      To change individual components, delete the FMS include,
+      copy the FMS comopnent from ../compoments.xml,
+      and customize the component root or csh.
     </description>
-    <component name="fms" paths="FMS">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(FMS_GIT_TAG)"> FMS.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs>-Duse_libMPI -Duse_netCDF $(F2003_FLAGS) -DMAXFIELDMETHODS_=600</cppDefs>
-      </compile>
-    </component>
-
-    <component name="mom6_symmetric" requires="fms" paths="mom6/src/MOM6/config_src/memory/dynamic_symmetric mom6/src/MOM6/config_src/drivers/FMS_cap mom6/src/MOM6/src/*/ mom6/src/MOM6/src/*/*/ mom6/src/MOM6/config_src/external/MARBL mom6/src/MOM6/config_src/external/ODA_hooks mom6/src/MOM6/config_src/external/stochastic_physics mom6/src/MOM6/config_src/external/drifters mom6/src/MOM6/config_src/external/database_comms mom6/src/ocean_BGC/generic_tracers mom6/src/ocean_BGC/mocsy/src mom6/src/MOM6/pkg/GSW-Fortran/modules mom6/src/MOM6/pkg/GSW-Fortran/toolbox mom6/src/MOM6/config_src/infra/FMS2">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-              <codeBase version="$(MOM6_GIT_TAG)"> CEFI-regional-MOM6.git </codeBase>
-        <csh><![CDATA[
-          mv CEFI-regional-MOM6 mom6
-        ]]></csh>
-      </source>
-      <compile>
-        <cppDefs><![CDATA[ $(F2003_FLAGS) -DUSE_FMS2_IO -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER  -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'" ]]></cppDefs>
-        <!--makeOverrides>OPENMP=""</makeOverrides>  openmp switch for MOM6 may cause crash -->
-      </compile>
-    </component>
-
-    <component name="sis2" paths="mom6/src/SIS2/config_src/dynamic_symmetric mom6/src/SIS2/config_src/external/Icepack_interfaces mom6/src/SIS2/src mom6/src/icebergs/src mom6/src/ice_param" requires="fms mom6_symmetric" includeDir="$root/$(LIBS_ROOT)/src/mom6/src/MOM6/src/framework" >
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(ICEPARAM_GIT_TAG)"> ice_param.git </codeBase>
-      </source>
-      <compile>
-         <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
-      </compile>
-    </component>
-
-    <component name="land_null" paths="mom6/src/land_null" requires="fms">
-      <description domainName="NA" communityName="NA" communityVersion="NA" communityGrid="NA"/>
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(NULL_TAG)"> land_null.git </codeBase>
-      </source>
-    </component>
-
-    <component name="atmos_null" paths="mom6/src/atmos_null" requires="fms">
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(NULL_TAG)"> atmos_null.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs>$(F2003_FLAGS) </cppDefs>
-      </compile>
-    </component>
-
-    <component name="coupler" paths="mom6/src/coupler/full mom6/src/coupler/shared" requires="fms land_null atmos_null sis2 mom6_symmetric">
-      <description domainName="FMS Coupler" communityName="coupler" communityVersion="$(CPL_GIT_TAG)" communityGrid=""/>
-      <source versionControl="git" root="https://github.com/NOAA-GFDL">
-        <codeBase version="$(CPL_GIT_TAG)"> coupler.git </codeBase>
-      </source>
-      <compile>
-        <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_USE_LEGACY_LAND_ -Duse_AM3_physics -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
-      </compile>
-    </component>
+    <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='ATMOS_NULL']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='COUPLER']/component)"/>
   </experiment>
 
-  <experiment name="CEFI_NWA12_physics_V2" inherit="MOM6_SIS2_GENERIC_4P_compile_symm">
+  <experiment name="CEFI_NWA12_physics_V2" inherit="$(COMPILE_EXP)">
     <description>
     </description>
     <input>
@@ -440,7 +382,7 @@ MOM_OVERRIDE_EOF
          cp diag_table input.nml metadata.out/
          cp INPUT/*_input INPUT/*_override metadata.out/
          # Save the Git commit hash for each source code submodule
-         git -C $root/$(LIBS_ROOT)/src/mom6 submodule status --recursive > metadata.out/git_submodule_status
+         git -C $root/$(COMPILE_EXP)/src/.CEFI-regional-MOM6 submodule status --recursive > metadata.out/git_submodule_status
          # Archive a copy of the xml used to run the model and the run script (fre sets these)
          cp $rtsxml metadata.out/
          cp $scriptName metadata.out/runscript.csh

--- a/xmls/NWA12/CEFI_NWA12_physics.xml
+++ b/xmls/NWA12/CEFI_NWA12_physics.xml
@@ -89,11 +89,15 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_physics.xml CEFI_NWA12_physics
   <!-- This automatically determines the start year of the model run, used to include the first forcing files. Do not change. -->
   <property name="append_to_setup_csh" value="set fyear=`echo $baseDate | cut -c1-4`"/>
 
-  <setup>
+   <setup>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc5.intel23'])"/>
+    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc5.intel25'])"/>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc5-intel23'])"/>
+    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc5-intel25'])"/>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc6.intel23'])"/>
+    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='ncrc6.intel25'])"/>
     <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel23'])"/>
+    <xi:include href="../xml_include/xml_building_blocks/platforms.xml" xpointer="xpointer(//freInclude/platform[@name='gfdl.ncrc6-intel25'])"/>
   </setup>
 
   <!-- COMPILE -->

--- a/xmls/NWA12/CEFI_NWA12_physics.xml
+++ b/xmls/NWA12/CEFI_NWA12_physics.xml
@@ -16,7 +16,7 @@ module use -a /ncrc/home2/fms/local/modulefiles
 module load fre/bronx-23
 
 Compile and build mom6-sis2-cobalt:
-fremake -x CEFI_NWA12_physics.xml -p ncrc6.intel23 -t prod,hdf5 FMS2_MOM6_SIS2_COBALT_compile_symm
+fremake -x CEFI_NWA12_physics.xml -p ncrc6.intel23 -t prod,hdf5 FMS2_MOM6_SIS2_compile_symm
 
 Run experiment
 frerun -x CEFI_NWA12_physics.xml -p ncrc6.intel23 -t prod,hdf5 CEFI_NWA12_physics_V2
@@ -101,7 +101,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_physics.xml CEFI_NWA12_physics
   <!-- git tag for CEFI-regional-MOM6 source code -->
   <property name="CEFI_GIT_TAG" value="main"/>
   <!-- Name of the compile experiment: -->
-  <property name="COMPILE_EXP" value="FMS2_MOM6_SIS2_COBALT_compile_symm"/>
+  <property name="COMPILE_EXP" value="FMS2_MOM6_SIS2_compile_symm"/>
   <!-- Insert the freInclude for each component from ../components.xml, as defined by the entity at the top -->
   &include_components;
 
@@ -115,7 +115,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_physics.xml CEFI_NWA12_physics
       and customize the component root or csh.
     </description>
     <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>
-    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
+    <xi:include xpointer="xpointer(//freInclude[@name='MOM6_ONLY']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
     <xi:include xpointer="xpointer(//freInclude[@name='ATMOS_NULL']/component)"/>

--- a/xmls/NWA12/CEFI_NWA12_physics.xml
+++ b/xmls/NWA12/CEFI_NWA12_physics.xml
@@ -111,7 +111,7 @@ frecheck -r layout -p ncrc6.intel23 -x CEFI_NWA12_physics.xml CEFI_NWA12_physics
       Each component is defined as a freInclude ultimately sourced from ../components.xml.
       To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
       To change individual components, delete the FMS include,
-      copy the FMS comopnent from ../compoments.xml,
+      copy the FMS comopnent from ../components.xml,
       and customize the component root or csh.
     </description>
     <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>

--- a/xmls/README.md
+++ b/xmls/README.md
@@ -49,24 +49,24 @@ git clone -b main https://github.com/NOAA-GFDL/CEFI-regional-MOM6.git
 # compile and build CEFI MOM6-SIS2-COBALT
 ```console
 cd CEFI-regional-MOM6/xmls/NWA12
-fremake -x CEFI_NWA12_cobalt.xml -p ncrc5.intel22 -t prod MOM6_SIS2_GENERIC_4P_compile_symm
+fremake -x CEFI_NWA12_cobalt.xml -p ncrc5.intel22 -t prod FMS2_MOM6_SIS2_COBALT_compile_symm
 ```
-The above step will git clone the source codes and prepare makefiles under `/gpfs/f5/cefi/scratch/<First.Last>/fre/cefi/NWA12/MOM6_SIS2_GENERIC_4P_compile_symm`.
+The above step will git clone the source codes and prepare makefiles under `/gpfs/f5/cefi/scratch/<First.Last>/fre/cefi/NWA12/FMS2_MOM6_SIS2_COBALT_compile_symm`.
 Once its done, user can submit a job for compiling/building MOM6-SIS2-COBALT:
 ```console
-sleep 1; sbatch /gpfs/f5/cefi/scratch/Yi-cheng.Teng/fre/cefi/NWA12/MOM6_SIS2_GENERIC_4P_compile_symm/ncrc5.intel22-prod/exec/compile_MOM6_SIS2_GENERIC_4P_compile_symm.csh
+sleep 1; sbatch /gpfs/f5/cefi/scratch/Yi-cheng.Teng/fre/cefi/NWA12/FMS2_MOM6_SIS2_COBALT_compile_symm/ncrc5.intel22-prod/exec/compile_FMS2_MOM6_SIS2_COBALT_compile_symm.csh
 ```
-User can check /gpfs/f5/cefi/scratch/<First.Last>/fre/cefi/NWA12/MOM6_SIS2_GENERIC_4P_compile_symm/ncrc5.intel22-prod/exec/compile_MOM6_SIS2_GENERIC_4P_compile_symm.csh.oJOB_ID to monitor the progress.
+User can check /gpfs/f5/cefi/scratch/<First.Last>/fre/cefi/NWA12/FMS2_MOM6_SIS2_COBALT_compile_symm/ncrc5.intel22-prod/exec/compile_FMS2_MOM6_SIS2_COBALT_compile_symm.csh.oJOB_ID to monitor the progress.
 If the job is completed successfully, you should be able to find the executable file:
 ```console
-ls -l -h /gpfs/f5/cefi/scratch/Yi-cheng.Teng/fre/cefi/NWA12/MOM6_SIS2_GENERIC_4P_compile_symm/ncrc5.intel22-prod/exec/fms_MOM6_SIS2_GENERIC_4P_compile_symm.x
+ls -l -h /gpfs/f5/cefi/scratch/Yi-cheng.Teng/fre/cefi/NWA12/FMS2_MOM6_SIS2_COBALT_compile_symm/ncrc5.intel22-prod/exec/fms_FMS2_MOM6_SIS2_COBALT_compile_symm.x
 ```
 # conduct 30-year hindcast simulation in NWA12 domain:
 The total length of the model simulation, in years, is controlled by the following parameter in the XML file:
 `<property name="PROD_SIMTIME" value="30"/>`
 Users can change this value to their desired simulated length. To conduct simulation, first do `frerun`:
 ```console
-frerun -x CEFI_NWA12_cobalt.xml -p ncrc5.intel22 -t prod CEFI_NWA12_COBALT_V1 
+frerun -x CEFI_NWA12_cobalt.xml -p ncrc5.intel22 -t prod CEFI_NWA12_COBALT_V1
 ```
 Once the aboe step is done, it will create a job script `/gpfs/f5/cefi/scratch/<First.Last>/fre/cefi/NWA12/CEFI_NWA12_COBALT_V1/ncrc5.intel22-prod/scripts/run/CEFI_NWA12_COBALT_V1`.
 To submit the simulation, simply type:

--- a/xmls/components.xml
+++ b/xmls/components.xml
@@ -2,7 +2,7 @@
 <!-- This XML is intended to be inserted into FRE xmls as an ENTITY. -->
 
 <!-- FRE needs the following properties -->
-<property name="PROG_MAIN" value="FMScoupler/coupler_main.o"/>
+<property name="PROG_MAIN" value="coupler/coupler_main.o"/>
 <property name="LIBS_ROOT" value="$(COMPILE_EXP)"/>
 
 <freInclude name="FMS">

--- a/xmls/components.xml
+++ b/xmls/components.xml
@@ -33,8 +33,9 @@
   </component>
 </freInclude>
 
-<freInclude name="MOM6_SYMMETRIC">
-  <component name="mom6_symmetric" requires="fms" paths="MOM6/config_src/memory/dynamic_symmetric MOM6/config_src/drivers/FMS_cap MOM6/src/*/ MOM6/src/*/*/ MOM6/config_src/external/MARBL MOM6/config_src/external/ODA_hooks MOM6/config_src/external/stochastic_physics MOM6/config_src/external/drifters MOM6/config_src/external/database_comms ocean_BGC/generic_tracers ocean_BGC/mocsy/src MOM6/pkg/GSW-Fortran/modules MOM6/pkg/GSW-Fortran/toolbox MOM6/config_src/infra/FMS2">
+<!-- MOM6 with ocean_BGC -->
+<freInclude name="MOM6_BGC">
+  <component name="mom6" requires="fms" paths="MOM6/config_src/memory/dynamic_symmetric MOM6/config_src/drivers/FMS_cap MOM6/src/*/ MOM6/src/*/*/ MOM6/config_src/external/MARBL MOM6/config_src/external/ODA_hooks MOM6/config_src/external/stochastic_physics MOM6/config_src/external/drifters MOM6/config_src/external/database_comms ocean_BGC/generic_tracers ocean_BGC/mocsy/src MOM6/pkg/GSW-Fortran/modules MOM6/pkg/GSW-Fortran/toolbox MOM6/config_src/infra/FMS2">
     <source versionControl="none" root=".">
       <codeBase version="none"> placeholder </codeBase>
     </source>
@@ -44,8 +45,20 @@
   </component>
 </freInclude>
 
+<!-- MOM6 without ocean_BGC -->
+<freInclude name="MOM6_ONLY">
+  <component name="mom6" requires="fms" paths="MOM6/config_src/memory/dynamic_symmetric MOM6/config_src/drivers/FMS_cap MOM6/src/*/ MOM6/src/*/*/ MOM6/config_src/external/MARBL MOM6/config_src/external/ODA_hooks MOM6/config_src/external/stochastic_physics MOM6/config_src/external/drifters MOM6/config_src/external/database_comms MOM6/config_src/external/GFDL_ocean_BGC MOM6/pkg/GSW-Fortran/modules MOM6/pkg/GSW-Fortran/toolbox MOM6/config_src/infra/FMS2">
+    <source versionControl="none" root=".">
+      <codeBase version="none"> placeholder </codeBase>
+    </source>
+    <compile>
+      <cppDefs><![CDATA[ $(F2003_FLAGS) -DUSE_FMS2_IO -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'" ]]></cppDefs>
+    </compile>
+  </component>
+</freInclude>
+
 <freInclude name="SIS2">
-  <component name="sis2" paths="SIS2/config_src/dynamic_symmetric SIS2/config_src/external/Icepack_interfaces SIS2/src icebergs/src ice_param" requires="fms mom6_symmetric" includeDir="$root/$(COMPILE_EXP)/src/MOM6/src/framework">
+  <component name="sis2" paths="SIS2/config_src/dynamic_symmetric SIS2/config_src/external/Icepack_interfaces SIS2/src icebergs/src ice_param" requires="fms mom6" includeDir="$root/$(COMPILE_EXP)/src/MOM6/src/framework">
     <source versionControl="none" root=".">
       <codeBase version="none"> placeholder </codeBase>
     </source>
@@ -56,7 +69,7 @@
 </freInclude>
 
 <freInclude name="ICEPACK">
-  <component name="Icepack" paths="Icepack/columnphysics" requires="fms mom6_symmetric" includeDir="$root/$(COMPILE_EXP)/src/MOM6/src/framework" >
+  <component name="Icepack" paths="Icepack/columnphysics" requires="fms mom6" includeDir="$root/$(COMPILE_EXP)/src/MOM6/src/framework" >
      <source versionControl="none" root=".">
       <codeBase version="none"> placeholder </codeBase>
     </source>
@@ -86,7 +99,7 @@
 </freInclude>
 
 <freInclude name="COUPLER">
-  <component name="coupler" paths="coupler/full coupler/shared" requires="fms land_null atmos_null sis2 mom6_symmetric">
+  <component name="coupler" paths="coupler/full coupler/shared" requires="fms land_null atmos_null sis2 mom6">
     <source versionControl="none" root=".">
       <codeBase version="none"> placeholder </codeBase>
     </source>

--- a/xmls/components.xml
+++ b/xmls/components.xml
@@ -1,0 +1,97 @@
+
+<!-- This XML is intended to be inserted into FRE xmls as an ENTITY. -->
+
+<!-- FRE needs the following properties -->
+<property name="PROG_MAIN" value="FMScoupler/coupler_main.o"/>
+<property name="LIBS_ROOT" value="$(COMPILE_EXP)"/>
+
+<freInclude name="FMS">
+  <component name="fms" paths="FMS">
+    <!-- The FMS component clones the CEFI-regional-MOM6 repository, which includes
+    submodules for every component. All of the following components will
+    use these submodules, so we place symlinks to them in a slightly easier
+    to find location. All of the components after this have a
+    source block that doesn't do anything, since the code has already been obtained.
+    (Note that because the placeholder source blocks don't do anything,
+    csh blocks cannot be added to them.) -->
+    <source versionControl="git" root="https://github.com/NOAA-GFDL/">
+      <codeBase version="$(CEFI_GIT_TAG)">CEFI-regional-MOM6.git</codeBase>
+      <csh><![CDATA[
+          # Hide the CEFI-regional-MOM6 repository and put links to the
+          # source code submodules in the top level src/ directory
+          mv CEFI-regional-MOM6 .CEFI-regional-MOM6
+          foreach subpath ( .CEFI-regional-MOM6/src/* )
+          if ( -d "$subpath" ) then
+              ln -s $subpath .
+          endif
+          end
+      ]]></csh>
+    </source>
+    <compile>
+      <cppDefs>-Duse_libMPI -Duse_netCDF $(F2003_FLAGS) -DMAXFIELDMETHODS_=600</cppDefs>
+    </compile>
+  </component>
+</freInclude>
+
+<freInclude name="MOM6_SYMMETRIC">
+  <component name="mom6_symmetric" requires="fms" paths="MOM6/config_src/memory/dynamic_symmetric MOM6/config_src/drivers/FMS_cap MOM6/src/*/ MOM6/src/*/*/ MOM6/config_src/external/MARBL MOM6/config_src/external/ODA_hooks MOM6/config_src/external/stochastic_physics MOM6/config_src/external/drifters MOM6/config_src/external/database_comms ocean_BGC/generic_tracers ocean_BGC/mocsy/src MOM6/pkg/GSW-Fortran/modules MOM6/pkg/GSW-Fortran/toolbox MOM6/config_src/infra/FMS2">
+    <source versionControl="none" root=".">
+      <codeBase version="none"> placeholder </codeBase>
+    </source>
+    <compile>
+      <cppDefs><![CDATA[ $(F2003_FLAGS) -DUSE_FMS2_IO -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'" ]]></cppDefs>
+    </compile>
+  </component>
+</freInclude>
+
+<freInclude name="SIS2">
+  <component name="sis2" paths="SIS2/config_src/dynamic_symmetric SIS2/config_src/external/Icepack_interfaces SIS2/src icebergs/src ice_param" requires="fms mom6_symmetric" includeDir="$root/$(COMPILE_EXP)/src/MOM6/src/framework">
+    <source versionControl="none" root=".">
+      <codeBase version="none"> placeholder </codeBase>
+    </source>
+    <compile>
+        <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
+    </compile>
+  </component>
+</freInclude>
+
+<freInclude name="ICEPACK">
+  <component name="Icepack" paths="Icepack/columnphysics" requires="fms mom6_symmetric" includeDir="$root/$(COMPILE_EXP)/src/MOM6/src/framework" >
+     <source versionControl="none" root=".">
+      <codeBase version="none"> placeholder </codeBase>
+    </source>
+    <compile>
+        <cppDefs><![CDATA[]]></cppDefs>
+    </compile>
+  </component>
+</freInclude>
+
+<freInclude name="LAND_NULL">
+  <component name="land_null" paths="land_null" requires="fms">
+    <source versionControl="none" root=".">
+      <codeBase version="none"> placeholder </codeBase>
+    </source>
+  </component>
+</freInclude>
+
+<freInclude name="ATMOS_NULL">
+  <component name="atmos_null" paths="atmos_null" requires="fms">
+    <source versionControl="none" root=".">
+      <codeBase version="none"> placeholder </codeBase>
+    </source>
+    <compile>
+      <cppDefs>$(F2003_FLAGS) </cppDefs>
+    </compile>
+  </component>
+</freInclude>
+
+<freInclude name="COUPLER">
+  <component name="coupler" paths="coupler/full coupler/shared" requires="fms land_null atmos_null sis2 mom6_symmetric">
+    <source versionControl="none" root=".">
+      <codeBase version="none"> placeholder </codeBase>
+    </source>
+    <compile>
+      <cppDefs><![CDATA[$(F2003_FLAGS) -DUSE_FMS2_IO -D_USE_LEGACY_LAND_ -Duse_AM3_physics -D_FILE_VERSION="'"`git-version-string $<`"'"]]></cppDefs>
+    </compile>
+  </component>
+</freInclude>


### PR DESCRIPTION
This closes #287 by using the approach I proposed there and @yichengt900 improved. The FMS component clones the CEFI-regional-MOM6 repository and checks out the specified branch/tag, and all of the other components do not clone any additional code. 

While cleaning up the XMLs, I took the opportunity to move all of the components to a shared XML. In components.xml, each component is placed inside its own freInclude. In the actual experiment XMLs, the component XML is defined as an entity
```xml
<!DOCTYPE experimentSuite [
  <!ENTITY include_components SYSTEM "../components.xml">
]>
```
and then inserted using `&include_components;`. Then the specific components can be included using <xi:include>. This reduces the compile experiment to:
```xml
<experiment name="$(COMPILE_EXP)">
  <description>
    Make the executable for ocean-ice experiments.
    Each component is defined as a freInclude ultimately sourced from ../components.xml.
    To check out a specific release of the CEFI code base, set CEFI_GIT_TAG.
    To change individual components, delete the FMS include,
    copy the FMS comopnent from ../compoments.xml,
    and customize the component root or csh.
  </description>
  <xi:include xpointer="xpointer(//freInclude[@name='FMS']/component)"/>
  <xi:include xpointer="xpointer(//freInclude[@name='MOM6_SYMMETRIC']/component)"/>
  <xi:include xpointer="xpointer(//freInclude[@name='SIS2']/component)"/>
  <xi:include xpointer="xpointer(//freInclude[@name='LAND_NULL']/component)"/>
  <xi:include xpointer="xpointer(//freInclude[@name='ATMOS_NULL']/component)"/>
  <xi:include xpointer="xpointer(//freInclude[@name='COUPLER']/component)"/>
</experiment>
```

I would have liked to point the <xi:include> directly to the components.xml, but I couldn't find a way to do this without hitting an error caused by an additional and unexpected attribute getting injected into the component when including using href. 

One thing to check is the NEP XML, which includes the Icepack component. I tried to preserve how this was defined previously, but does it actually get used? 