### PR TITLE
Point coupler to experimental wind/current branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,5 +44,5 @@
 	branch = 2025.03
 [submodule "src/coupler"]
 	path = src/coupler
-	url = https://github.com/NOAA-GFDL/FMScoupler.git
-	branch = 2025.03
+	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/FMScoupler.git
+	branch = feature/wind_current_coef


### PR DESCRIPTION
This changes the coupler submodule to point to the NOAA-CEFI-Regional-Ocean-Modeling fork instead of NOAA-GFDL, and also uses my branch with the experimental wind/current modification. 

The new branch adds the namelist option `wind_current_coefficient` to allow scaling of the ocean surface current the coupler subtracts from the wind.
```xml
<namelist name="surface_flux_nml">
  wind_current_coef = 0.5
</namelist>
```

I didn't change any of the XMLs in this PR, and when not set the coefficient defaults to 1.0 which should reproduce old results. This will make it easier to switch to using the coefficient though. 